### PR TITLE
Fully-qualify `Some` and `None` in generated code

### DIFF
--- a/snafu-derive/src/lib.rs
+++ b/snafu-derive/src/lib.rs
@@ -713,13 +713,13 @@ impl<'a> ErrorImpl<'a> {
                         } = *source_field;
                         quote! {
                             #enum_name::#variant_name { ref #field_name, .. } => {
-                                Some(std::borrow::Borrow::borrow(#field_name))
+                                std::option::Option::Some(std::borrow::Borrow::borrow(#field_name))
                             }
                         }
                     }
                     None => {
                         quote! {
-                            #enum_name::#variant_name { .. } => { None }
+                            #enum_name::#variant_name { .. } => { std::option::Option::None }
                         }
                     }
                 }
@@ -809,11 +809,11 @@ impl<'a> ErrorCompatImpl<'a> {
                     ..
                 } = *backtrace_field;
                 quote! {
-                    #enum_name::#variant_name { ref #field_name, .. } => { Some(#field_name) }
+                    #enum_name::#variant_name { ref #field_name, .. } => { std::option::Option::Some(#field_name) }
                 }
             } else {
                 quote! {
-                    #enum_name::#variant_name { .. } => { None }
+                    #enum_name::#variant_name { .. } => { std::option::Option::None }
                 }
             }
         }).collect()

--- a/tests/name-conflicts.rs
+++ b/tests/name-conflicts.rs
@@ -1,0 +1,23 @@
+extern crate snafu;
+
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+enum VariantNamedNone {
+    None,
+}
+
+#[derive(Debug, Snafu)]
+enum VariantNamedSome<T> {
+    Some { value: T },
+}
+
+#[derive(Debug, Snafu)]
+enum VariantNamedOk<T> {
+    Ok { value: T },
+}
+
+#[derive(Debug, Snafu)]
+enum VariantNamedErr<T> {
+    Err { value: T },
+}


### PR DESCRIPTION
Fixes #51