### PR TITLE
add failing test for using errors across threads

### DIFF
--- a/tests/thread_error.rs
+++ b/tests/thread_error.rs
@@ -1,0 +1,36 @@
+// This test asserts that errors can be used across threads.
+extern crate snafu;
+
+use std::sync::mpsc;
+use std::thread;
+
+use snafu::{ResultExt, Snafu};
+
+mod api {
+    pub type Error = Box<dyn std::error::Error + 'static>;
+
+    pub fn function() -> Result<i32, Error> {
+        Ok(42)
+    }
+}
+
+#[derive(Debug, Snafu)]
+enum Error {
+    Authenticating { user_id: i32, source: api::Error },
+}
+
+fn example() -> Result<(), Error> {
+    api::function().context(Authenticating { user_id: 42 })?;
+    Ok(())
+}
+
+#[test]
+fn implements_thread_safe_error() {
+    let (tx, rx) = mpsc::channel();
+
+    thread::spawn(move || {
+        tx.send(example()).unwrap();
+    });
+
+    let item = rx.recv().unwrap();
+}


### PR DESCRIPTION
hi @shepmaster! :smiley_cat: 

thanks for this sweet module, i've started using it in my own wee [`nest`](https://github.com/ahdinosaur/nest) module (my first Rust module!). :bird: 

i've run into a recent problem, where i want to do something (watch filesystem changes) in a new thread, then send results (with my `snafu` errors) over a channel back to the main thread.

some of my errors use wrapped boxes, and i think these are giving me an error when trying to send.

i made a simple failing test that matches what i'm trying to do, where the error is:

```
error[E0277]: `(dyn std::error::Error + 'static)` cannot be sent between threads safely
  --> tests/thread_error.rs:31:5
   |
31 |     thread::spawn(move || {
   |     ^^^^^^^^^^^^^ `(dyn std::error::Error + 'static)` cannot be sent between threads safely
   |
   = help: the trait `std::marker::Send` is not implemented for `(dyn std::error::Error + 'static)`
   = note: required because of the requirements on the impl of `std::marker::Send` for `std::ptr::Unique<(dyn std::error::Error + 'static)>`
   = note: required because it appears within the type `std::boxed::Box<(dyn std::error::Error + 'static)>`
   = note: required because it appears within the type `Error`
   = note: required because it appears within the type `std::result::Result<(), Error>`
   = note: required because of the requirements on the impl of `std::marker::Send` for `std::sync::mpsc::Sender<std::result::Result<(), Error>>`
   = note: required because it appears within the type `[closure@tests/thread_error.rs:31:19: 33:6 tx:std::sync::mpsc::Sender<std::result::Result<(), Error>>]`
   = note: required by `std::thread::spawn`
```

maybe i'm approaching this problem totally wrong, i'm not sure.

i also tried to follow [this suggestion](https://stackoverflow.com/a/25649509) and use `Box<dyn std::error::Error + Send>` as my wrapped box error, but that didn't work because:

```
error[E0277]: the trait bound `std::boxed::Box<dyn std::error::Error + std::marker::Send>: std::borrow::Borrow<dyn std::error::Error>` is not satisfied
  --> tests/thread_error.rs:17:17
   |
17 | #[derive(Debug, Snafu)]
   |                 ^^^^^ the trait `std::borrow::Borrow<dyn std::error::Error>` is not implemented for `std::boxed::Box<dyn std::error::Error + std::marker::Send>`
   |
   = help: the following implementations were found:
             <std::boxed::Box<Error> as std::borrow::Borrow<(dyn std::error::Error + 'static)>>
             <std::boxed::Box<T> as std::borrow::Borrow<T>>
   = note: required by `std::borrow::Borrow::borrow`
```

so then i tried diving into the `snafu-derive` code and seeing if i could make the borrow trait happy, but again i'm not sure what i'm doing. :sweat_smile: 

cheers!