### PR TITLE
Implement Doc Comments as Default Display Implementations

### DIFF
--- a/tests/doc_comment.rs
+++ b/tests/doc_comment.rs
@@ -1,0 +1,40 @@
+extern crate snafu;
+
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+enum Error {
+    /// No user available.
+    /// You may need to specify one.
+    ///
+    /// Here is a more detailed description.
+    MissingUser,
+    /// This is just a doc comment.
+    #[snafu(display("This is {}", stronger))]
+    Stronger { stronger: &'static str },
+}
+
+#[test]
+fn implements_error() {
+    fn check<T: std::error::Error>() {}
+    check::<Error>();
+}
+
+#[test]
+fn uses_doc_comment() {
+    assert_eq!(
+        Error::MissingUser.to_string(),
+        "No user available. You may need to specify one.",
+    );
+}
+
+#[test]
+fn display_is_stronger_than_doc_comment() {
+    assert_eq!(
+        Error::Stronger {
+            stronger: "always stronger!"
+        }
+        .to_string(),
+        "This is always stronger!",
+    );
+}


### PR DESCRIPTION
If there is no #[snafu(display(...))] attribute on a variant, but there is a doc comment, the doc comment is now chosen as the implementation of Display for the variant.

Resolves #106