### PR TITLE
Improve errors for misused attributes

### DIFF
--- a/compatibility-tests/compile-fail/tests/ui/attribute-duplication.rs
+++ b/compatibility-tests/compile-fail/tests/ui/attribute-duplication.rs
@@ -1,0 +1,51 @@
+mod enum_duplication {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(visibility(pub))]
+    #[snafu(visibility(pub))]
+    enum EnumError {
+        #[snafu(display("an error variant"))]
+        #[snafu(display("should not allow duplicate display"))]
+        #[snafu(visibility(pub))]
+        #[snafu(visibility(pub))]
+        AVariant {
+            #[snafu(source(from(EnumError, Box::new)))]
+            #[snafu(backtrace(delegate))]
+            source: Box<EnumError>,
+            #[snafu(source(from(EnumError, Box::new)))]
+            #[snafu(backtrace(delegate))]
+            source2: Box<EnumError>,
+            #[snafu(source)]
+            #[snafu(backtrace(delegate))]
+            source3: String,
+            #[snafu(source)]
+            #[snafu(source)]
+            #[snafu(backtrace(delegate))]
+            source4: String,
+
+            #[snafu(backtrace)]
+            backtrace1: String,
+            #[snafu(backtrace)]
+            backtrace2: String,
+            #[snafu(backtrace)]
+            #[snafu(backtrace)]
+            #[snafu(backtrace)]
+            backtrace3: String,
+        },
+    }
+}
+
+mod struct_duplication {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    enum UsableError {}
+
+    #[derive(Debug, Snafu)]
+    #[snafu(source(from(UsableError, Box::new)))]
+    #[snafu(source(from(UsableError, Box::new)))]
+    struct StructError(Box<UsableError>);
+}
+
+fn main() {}

--- a/compatibility-tests/compile-fail/tests/ui/attribute-duplication.stderr
+++ b/compatibility-tests/compile-fail/tests/ui/attribute-duplication.stderr
@@ -1,0 +1,83 @@
+error: Multiple 'visibility' attributes are not supported on an error enum; found a duplicate here:
+ --> $DIR/attribute-duplication.rs:7:10
+  |
+7 |     enum EnumError {
+  |          ^^^^^^^^^
+
+error: Multiple 'source' attributes are not supported on one field; found a duplicate here:
+  --> $DIR/attribute-duplication.rs:25:13
+   |
+25 |             source4: String,
+   |             ^^^^^^^
+
+error: Multiple 'backtrace' attributes are not supported on one field; found a duplicate here:
+  --> $DIR/attribute-duplication.rs:34:13
+   |
+34 |             backtrace3: String,
+   |             ^^^^^^^^^^
+
+error: Multiple 'source' attributes are not supported within an error variant; found a duplicate here:
+  --> $DIR/attribute-duplication.rs:21:13
+   |
+21 |             source3: String,
+   |             ^^^^^^^
+
+error: Multiple 'source' attributes are not supported within an error variant; found a duplicate here:
+  --> $DIR/attribute-duplication.rs:25:13
+   |
+25 |             source4: String,
+   |             ^^^^^^^
+
+error: Multiple 'backtrace' attributes are not supported within an error variant; found a duplicate here:
+  --> $DIR/attribute-duplication.rs:30:13
+   |
+30 |             backtrace2: String,
+   |             ^^^^^^^^^^
+
+error: Multiple 'backtrace' attributes are not supported within an error variant; found a duplicate here:
+  --> $DIR/attribute-duplication.rs:34:13
+   |
+34 |             backtrace3: String,
+   |             ^^^^^^^^^^
+
+error: Multiple 'backtrace(delegate)' attributes are not supported within an error variant; found a duplicate here:
+  --> $DIR/attribute-duplication.rs:21:13
+   |
+21 |             source3: String,
+   |             ^^^^^^^
+
+error: Multiple 'backtrace(delegate)' attributes are not supported within an error variant; found a duplicate here:
+  --> $DIR/attribute-duplication.rs:25:13
+   |
+25 |             source4: String,
+   |             ^^^^^^^
+
+error: Cannot have 'backtrace' and 'backtrace(delegate)' fields in the same error variant
+  --> $DIR/attribute-duplication.rs:28:13
+   |
+28 |             backtrace1: String,
+   |             ^^^^^^^^^^
+
+error: Cannot have 'backtrace' and 'backtrace(delegate)' fields in the same error variant
+  --> $DIR/attribute-duplication.rs:15:13
+   |
+15 |             source: Box<EnumError>,
+   |             ^^^^^^
+
+error: Multiple 'display' attributes are not supported on an error variant; found a duplicate here:
+  --> $DIR/attribute-duplication.rs:12:9
+   |
+12 |         AVariant {
+   |         ^^^^^^^^
+
+error: Multiple 'visibility' attributes are not supported on an error variant; found a duplicate here:
+  --> $DIR/attribute-duplication.rs:12:9
+   |
+12 |         AVariant {
+   |         ^^^^^^^^
+
+error: Multiple 'source(from)' attributes are not supported on an error struct; found a duplicate here:
+  --> $DIR/attribute-duplication.rs:47:25
+   |
+47 |     #[snafu(source(from(UsableError, Box::new)))]
+   |                         ^^^^^^^^^^^

--- a/compatibility-tests/compile-fail/tests/ui/attribute-misuse.rs
+++ b/compatibility-tests/compile-fail/tests/ui/attribute-misuse.rs
@@ -1,0 +1,38 @@
+mod enum_misuse {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(display("display should not work here"))]
+    #[snafu(source(from(XXXX, Box::new)))]
+    #[snafu(source(true))]
+    #[snafu(backtrace)]
+    enum EnumError {
+        #[snafu(display("an error variant"))]
+        #[snafu(source(from(XXXX, Box::new)))]
+        #[snafu(backtrace)]
+        AVariant {
+            #[snafu(display("display should not work here"))]
+            #[snafu(visibility(pub))]
+            #[snafu(source(false))]
+            #[snafu(source(from(XXXX, Box::new)))]
+            a: String,
+        },
+    }
+}
+
+mod struct_misuse {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    enum UsableError {}
+
+    #[derive(Debug, Snafu)]
+    #[snafu(display("display should not work here"))]
+    #[snafu(source(from(UsableError, Box::new)))]
+    #[snafu(visibility(pub))]
+    #[snafu(source(true))]
+    #[snafu(backtrace)]
+    struct StructError(Box<UsableError>);
+}
+
+fn main() {}

--- a/compatibility-tests/compile-fail/tests/ui/attribute-misuse.stderr
+++ b/compatibility-tests/compile-fail/tests/ui/attribute-misuse.stderr
@@ -1,0 +1,77 @@
+error: 'display' attribute is only valid on variants of an error enum; attempted to place on this enum:
+ --> $DIR/attribute-misuse.rs:9:10
+  |
+9 |     enum EnumError {
+  |          ^^^^^^^^^
+
+error: 'source(from)' attribute is only valid on fields of an error variant; attempted to place on this enum:
+ --> $DIR/attribute-misuse.rs:9:10
+  |
+9 |     enum EnumError {
+  |          ^^^^^^^^^
+
+error: 'source(bool)' attribute is only valid on fields of an error variant; attempted to place on this enum:
+ --> $DIR/attribute-misuse.rs:9:10
+  |
+9 |     enum EnumError {
+  |          ^^^^^^^^^
+
+error: 'backtrace' attribute is only valid on fields of an error variant; attempted to place on this enum:
+ --> $DIR/attribute-misuse.rs:9:10
+  |
+9 |     enum EnumError {
+  |          ^^^^^^^^^
+
+error: 'source' attribute is only valid on fields of an error variant; attempted to place on this variant:
+  --> $DIR/attribute-misuse.rs:13:9
+   |
+13 |         AVariant {
+   |         ^^^^^^^^
+
+error: 'backtrace' attribute is only valid on fields of an error variant; attempted to place on this variant:
+  --> $DIR/attribute-misuse.rs:13:9
+   |
+13 |         AVariant {
+   |         ^^^^^^^^
+
+error: 'display' attribute is only valid on variants of an error enum; attempted to place on this field:
+  --> $DIR/attribute-misuse.rs:18:13
+   |
+18 |             a: String,
+   |             ^
+
+error: 'visibility' attribute is only valid on an error enum and its variants; attempted to place on this field:
+  --> $DIR/attribute-misuse.rs:18:13
+   |
+18 |             a: String,
+   |             ^
+
+error: Incompatible attributes ["source(false)", "source(from)"] specified on one field here:
+  --> $DIR/attribute-misuse.rs:18:13
+   |
+18 |             a: String,
+   |             ^
+
+error: 'display' attribute is only valid on variants of an error enum; attempted to place on this struct:
+  --> $DIR/attribute-misuse.rs:35:12
+   |
+35 |     struct StructError(Box<UsableError>);
+   |            ^^^^^^^^^^^
+
+error: 'visibility' attribute is only valid on an error enum and its variants; attempted to place on this struct:
+  --> $DIR/attribute-misuse.rs:35:12
+   |
+35 |     struct StructError(Box<UsableError>);
+   |            ^^^^^^^^^^^
+
+error: 'source(bool)' attribute is only valid on fields of an error variant; attempted to place on this struct:
+  --> $DIR/attribute-misuse.rs:35:12
+   |
+35 |     struct StructError(Box<UsableError>);
+   |            ^^^^^^^^^^^
+
+error: 'backtrace' attribute is only valid on fields of an error variant; attempted to place on this struct:
+  --> $DIR/attribute-misuse.rs:35:12
+   |
+35 |     struct StructError(Box<UsableError>);
+   |            ^^^^^^^^^^^


### PR DESCRIPTION
Fixes #105.

The first commit directly addresses the discussion in #105 by adding errors for cases of attribute misuse that were known to be wrong but didn't yet have errors.  Previously, the derive would just continue without the effect the user was trying to request.

The second commit addresses similar comments elsewhere in the file that suggested we warn if attributes are duplicated.  This wasn't discussed in #105 but seemed closely related.

---

**Testing done:**

Existing unit/doc tests still pass, and I added compile-fail tests to exercise each of the new error cases.