### PR TITLE
Specify minimum versions in Cargo.toml files where possible

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -75,11 +75,6 @@ v1_30_test_task:
   primary_test_script:
     - cd compatibility-tests/v1_30/
     - rustc --version
-    - cargo generate-lockfile
-    # These versions determined by trial and error
-    - cargo update -p backtrace --precise 0.3.30
-    - cargo update -p backtrace-sys --precise 0.1.28
-    - cargo update -p rustc-demangle --precise 0.1.13
     - cargo test
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
@@ -99,11 +94,5 @@ v1_18_test_task:
   primary_test_script:
     - cd compatibility-tests/v1_18/
     - rustc --version
-    - cargo generate-lockfile
-    # These versions determined by trial and error
-    - cargo update -p backtrace --precise 0.3.0
-    - cargo update -p backtrace-sys --precise 0.1.3
-    - cargo update -p libc --precise 0.2.7
-    - cargo update -p syn --precise 0.15.37
     - cargo test
   before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/compatibility-tests/v1_18/Cargo.toml
+++ b/compatibility-tests/v1_18/Cargo.toml
@@ -6,3 +6,9 @@ authors = ["Jake Goulding <jake.goulding@gmail.com>"]
 [dependencies]
 snafu = { path = "../..", default-features = false, features = ["backtraces"] }
 snafu-derive = { path = "../../snafu-derive" }
+
+# These versions are the last versions to support Rust 1.18
+backtrace = "= 0.3.0"
+backtrace-sys = "= 0.1.3"
+libc = "= 0.2.7"
+syn = "= 0.15.37"

--- a/compatibility-tests/v1_30/Cargo.toml
+++ b/compatibility-tests/v1_30/Cargo.toml
@@ -5,3 +5,8 @@ authors = ["Jake Goulding <jake.goulding@gmail.com>"]
 
 [dependencies]
 snafu = { path = "../..", default-features = false, features = ["rust_1_30", "backtraces"] }
+
+# These versions are the last versions to support Rust 1.30
+backtrace = "= 0.3.30"
+backtrace-sys = "= 0.1.28"
+rustc-demangle = "= 0.1.13"


### PR DESCRIPTION
This should make it easier to run these tests locally. The `-Z
minimal-versions` test still needs to use `--precise` because it
operates directly on the crate's Cargo.toml, which we don't want to
pollute with extraneous version requirements.