### PR TITLE
Make `source(from)` imply `source(true)`

### DIFF
--- a/compatibility-tests/compile-fail/tests/ui/attribute-duplication.stderr
+++ b/compatibility-tests/compile-fail/tests/ui/attribute-duplication.stderr
@@ -17,6 +17,12 @@ error: Multiple 'backtrace' attributes are not supported on one field; found a d
    |             ^^^^^^^^^^
 
 error: Multiple 'source' attributes are not supported within an error variant; found a duplicate here:
+  --> $DIR/attribute-duplication.rs:18:13
+   |
+18 |             source2: Box<EnumError>,
+   |             ^^^^^^^
+
+error: Multiple 'source' attributes are not supported within an error variant; found a duplicate here:
   --> $DIR/attribute-duplication.rs:21:13
    |
 21 |             source3: String,
@@ -39,6 +45,12 @@ error: Multiple 'backtrace' attributes are not supported within an error variant
    |
 34 |             backtrace3: String,
    |             ^^^^^^^^^^
+
+error: Multiple 'backtrace(delegate)' attributes are not supported within an error variant; found a duplicate here:
+  --> $DIR/attribute-duplication.rs:18:13
+   |
+18 |             source2: Box<EnumError>,
+   |             ^^^^^^^
 
 error: Multiple 'backtrace(delegate)' attributes are not supported within an error variant; found a duplicate here:
   --> $DIR/attribute-duplication.rs:21:13

--- a/snafu-derive/src/lib.rs
+++ b/snafu-derive/src/lib.rs
@@ -508,6 +508,7 @@ fn parse_snafu_enum(
                                         }
                                         source_attrs.add((), name.span());
                                         transformations.add((t, e), name.span());
+                                        is_source = Some(true);
                                     }
                                 }
                             }

--- a/src/guide/attributes.md
+++ b/src/guide/attributes.md
@@ -141,6 +141,11 @@ enum Error {
 struct ApiError(Box<Error>);
 ```
 
+Note: If you specify `#[snafu(source(from(...)))]` then the field
+will be treated as a source, even if it's not named "source" - in
+other words, `#[snafu(source(from(...)))]` implies
+`#[snafu(source)]`.
+
 ## Controlling backtraces
 
 If your error enum variant contains a backtrace but the field

--- a/tests/source_attributes.rs
+++ b/tests/source_attributes.rs
@@ -27,6 +27,11 @@ mod enabling {
             cause: InnerError,
         },
 
+        FromImpliesTrue {
+            #[snafu(source(from(InnerError, Box::new)))]
+            cause: Box<InnerError>,
+        },
+
         ExplicitFalse {
             #[snafu(source(false))]
             source: i32,
@@ -36,6 +41,7 @@ mod enabling {
     fn example() -> Result<(), Error> {
         inner().context(NoArgument)?;
         inner().context(ExplicitTrue)?;
+        inner().context(FromImpliesTrue)?;
         ExplicitFalse { source: 42 }.fail()?;
         Ok(())
     }


### PR DESCRIPTION
Fixes #124 - based on discussion from #109 about which attributes should be valid together.

This change makes `source(from(...))` imply `source(true)`.  This means you don't need two `source`-type attributes on a field that you intend to be a source but can't be named `source`.  (It's still valid to specify `source(from(...))` and `source(true)`, just redundant.)

The `attributes` section of the user's guide is updated with a note on this behavior.

---

**Testing done:**

Updated compile-fail results show that we catch more duplicates than we could before, because more fields are recognized as sources.

An updated unit test also shows this behavior in a more positive light.  :)