### PR TITLE
Fix parsing of multiple attributes inside `#[snafu(...)]`

### DIFF
--- a/tests/multiple_attributes.rs
+++ b/tests/multiple_attributes.rs
@@ -1,0 +1,25 @@
+extern crate snafu;
+
+mod error {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    pub(super) enum Error {
+        // We'll test both of these attributes inside `#[snafu(...)]`
+        #[snafu(visibility(pub(super)), display("Moo"))]
+        Alpha,
+    }
+}
+
+// Confirm `pub(super)` is applied to the generated struct
+#[test]
+fn is_visible() {
+    let _ = error::Alpha;
+}
+
+// Confirm `display("Moo")` is applied to the variant
+#[test]
+fn has_display() {
+    let err = error::Error::Alpha;
+    assert_eq!(format!("{}", err), "Moo");
+}


### PR DESCRIPTION
Fixes #135

This was simple when using shepmaster's suggestion and test case from #135 - parse and remove the parentheses at the list level rather than the attribute level because the parentheses aren't part of the attributes themselves.

---

**Testing done:**

New test case shows multiple attributes being accepted and applied correctly.