### PR TITLE
Replace `backtrace(delegate)` with `backtrace` on a source field

### DIFF
--- a/compatibility-tests/compile-fail/tests/ui/duplication-backtrace-delegate-attributes.rs
+++ b/compatibility-tests/compile-fail/tests/ui/duplication-backtrace-delegate-attributes.rs
@@ -4,8 +4,8 @@ use snafu::Snafu;
 enum EnumError {
     AVariant {
         // Should detect second attribute as duplicate
-        #[snafu(backtrace(delegate))]
-        #[snafu(backtrace(delegate))]
+        #[snafu(backtrace)]
+        #[snafu(backtrace)]
         source: String,
     },
 }

--- a/compatibility-tests/compile-fail/tests/ui/duplication-backtrace-delegate-attributes.stderr
+++ b/compatibility-tests/compile-fail/tests/ui/duplication-backtrace-delegate-attributes.stderr
@@ -1,5 +1,5 @@
 error: Multiple `backtrace` attributes are not supported on a field
  --> $DIR/duplication-backtrace-delegate-attributes.rs:8:17
   |
-8 |         #[snafu(backtrace(delegate))]
-  |                 ^^^^^^^^^^^^^^^^^^^
+8 |         #[snafu(backtrace)]
+  |                 ^^^^^^^^^

--- a/compatibility-tests/compile-fail/tests/ui/duplication-backtrace-delegate.rs
+++ b/compatibility-tests/compile-fail/tests/ui/duplication-backtrace-delegate.rs
@@ -7,7 +7,7 @@ enum EnumError {
         backtrace: Backtrace,
 
         // Second backtrace, this time a delegate, can't have both
-        #[snafu(backtrace(delegate))]
+        #[snafu(backtrace)]
         source: String,
     },
 }

--- a/compatibility-tests/compile-fail/tests/ui/duplication-backtrace-delegate.stderr
+++ b/compatibility-tests/compile-fail/tests/ui/duplication-backtrace-delegate.stderr
@@ -1,11 +1,12 @@
-error: Cannot have `backtrace` and `backtrace(delegate)` fields in the same error variant
+error: Cannot have `backtrace` field and `backtrace` attribute on a source field in the same error variant
+  --> $DIR/duplication-backtrace-delegate.rs:10:9
+   |
+10 | /         #[snafu(backtrace)]
+11 | |         source: String,
+   | |______________________^
+
+error: Cannot have `backtrace` field and `backtrace` attribute on a source field in the same error variant
  --> $DIR/duplication-backtrace-delegate.rs:7:9
   |
 7 |         backtrace: Backtrace,
   |         ^^^^^^^^^^^^^^^^^^^^
-
-error: Cannot have `backtrace` and `backtrace(delegate)` fields in the same error variant
-  --> $DIR/duplication-backtrace-delegate.rs:10:17
-   |
-10 |         #[snafu(backtrace(delegate))]
-   |                 ^^^^^^^^^^^^^^^^^^^

--- a/src/guide/attributes.md
+++ b/src/guide/attributes.md
@@ -172,7 +172,8 @@ enum Error {
 
 If your error contains other SNAFU errors which can report
 backtraces, you may wish to delegate returning a backtrace to
-those errors. Use `#[snafu(backtrace(delegate))]` to specify this:
+those errors. To specify this, use `#[snafu(backtrace)]` on the
+source field representing the other error:
 
 ```rust
 # mod another {
@@ -184,7 +185,7 @@ those errors. Use `#[snafu(backtrace(delegate))]` to specify this:
 #[derive(Debug, Snafu)]
 enum Error {
     MyError {
-        #[snafu(backtrace(delegate))]
+        #[snafu(backtrace)]
         source: another::Error,
     },
 }

--- a/tests/backtrace_delegation.rs
+++ b/tests/backtrace_delegation.rs
@@ -18,7 +18,7 @@ mod house {
 #[derive(Debug, Snafu)]
 enum Error {
     MovieTrope {
-        #[snafu(backtrace(delegate))]
+        #[snafu(backtrace)]
         source: house::Error,
     },
 }

--- a/tests/multiple_attributes.rs
+++ b/tests/multiple_attributes.rs
@@ -17,7 +17,7 @@ mod error {
         #[snafu(visibility(pub(super)), display("Moo"))]
         Alpha {
             // Ensure we can have multiple field attributes as well
-            #[snafu(source, backtrace(delegate))]
+            #[snafu(source, backtrace)]
             cause: InnerError,
         },
     }

--- a/tests/source_and_backtrace.rs
+++ b/tests/source_and_backtrace.rs
@@ -1,0 +1,28 @@
+extern crate snafu;
+
+use snafu::{Backtrace, ErrorCompat, ResultExt, Snafu};
+
+#[derive(Debug, Snafu)]
+enum InnerError {
+    InnerVariant { backtrace: Backtrace },
+}
+
+#[derive(Debug, Snafu)]
+enum Error {
+    SourceAndBacktraceAttrs {
+        // Testing source and backtrace attributes; the field should be recognized as a source,
+        // and allow us to get a backtrace delegated from the source error
+        #[snafu(source, backtrace)]
+        cause: InnerError,
+    },
+}
+
+fn example() -> Result<(), Error> {
+    InnerVariant.fail().context(SourceAndBacktraceAttrs)
+}
+
+#[test]
+fn delegated_backtrace_works() {
+    let e = example().unwrap_err();
+    ErrorCompat::backtrace(&e).unwrap();
+}


### PR DESCRIPTION
Fixes #125, see it for background.

As I was playing with some options, I came to believe that the clearest representation of this change is adding a flag to `SourceField` that represents whether the source field is a backtrace delegate.  We don't need the `backtrace_delegate` field in `VariantInfo` with its `Option<Field>`; all delegates are source fields, and we already have the source field information.

I was then able to simplify `parse_snafu_enum` by removing `backtrace_delegates` and `backtrace_delegate_location` - we can detect whether it's a delegate just by seeing if we got a backtrace attribute on a source field, both of which were already tracked, so we don't need separate tracking methods.

I added a friendly error if we do see `backtrace(delegate)`, and updated the tests and guide.  Updated compile-fail tests show the (even better?) errors for duplication.

No idea why rustfmt decided to rewrap some unchanged paragraphs, sorry :(

I'm interested in any feedback on this approach of moving knowledge of backtrace delegation to `SourceField`, and of course any other general feedback.