### PR TITLE
Fix parsing of source/backtrace with no parens

### DIFF
--- a/compatibility-tests/compile-fail/tests/ui/attribute-unparseable.rs
+++ b/compatibility-tests/compile-fail/tests/ui/attribute-unparseable.rs
@@ -1,0 +1,17 @@
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+enum InnerError {
+    InnerVariant,
+}
+
+#[derive(Debug, Snafu)]
+enum Error {
+    AVariant {
+        // Invalid identifier, and not a boolean; should error
+        #[snafu(source(5))]
+        a: InnerError,
+    },
+}
+
+fn main() {}

--- a/compatibility-tests/compile-fail/tests/ui/attribute-unparseable.stderr
+++ b/compatibility-tests/compile-fail/tests/ui/attribute-unparseable.stderr
@@ -1,0 +1,5 @@
+error: expected boolean literal or identifier
+  --> $DIR/attribute-unparseable.rs:12:24
+   |
+12 |         #[snafu(source(5))]
+   |                        ^

--- a/tests/multiple_attributes.rs
+++ b/tests/multiple_attributes.rs
@@ -1,13 +1,25 @@
 extern crate snafu;
 
+use snafu::{ResultExt, Snafu};
+
+#[derive(Debug, Snafu)]
+enum InnerError {
+    InnerVariant,
+}
+
 mod error {
+    use super::InnerError;
     use snafu::Snafu;
 
     #[derive(Debug, Snafu)]
     pub(super) enum Error {
         // We'll test both of these attributes inside `#[snafu(...)]`
         #[snafu(visibility(pub(super)), display("Moo"))]
-        Alpha,
+        Alpha {
+            // Ensure we can have multiple field attributes as well
+            #[snafu(source, backtrace(delegate))]
+            cause: InnerError,
+        },
     }
 }
 
@@ -17,9 +29,13 @@ fn is_visible() {
     let _ = error::Alpha;
 }
 
+fn example() -> Result<u8, InnerError> {
+    InnerVariant.fail()
+}
+
 // Confirm `display("Moo")` is applied to the variant
 #[test]
 fn has_display() {
-    let err = error::Error::Alpha;
+    let err = example().context(error::Alpha).unwrap_err();
     assert_eq!(format!("{}", err), "Moo");
 }


### PR DESCRIPTION
If a plain `source` or `backtrace` attribute were specified in a non-final
position in an attribute list, we would fail to parse them because we assumed
`input` would be empty if we were at the end of an attribute.  However, `input`
is the parse stream for the whole attribute list, not just the attribute; it
could contain a comma and further attributes.

This change checks more carefully whether we're at the end of an attribute by
looking for empty input or a comma that signifies another attribute is coming.
Error messages are also improved, because it uses `Lookahead1` to let syn track
the tokens we want to allow.

Fixes #146

---

**Testing done:**

A new compile-fail test is added to show the handling of invalid identifiers inside `source(...)` using `Lookahead1`, and the multiple-attributes test was updated to include the `snafu(source, backtrace)` case which wouldn't parse before this PR.

---

Note that there's a slight timing issue with #141, and I'll rebase one on top of the other as shepmaster prefers.  (GitHub won't let me layer them by creating a PR in shepmaster/snafu with a base branch on my own fork.)

Either this PR should change `backtrace(delegate)` to `backtrace` if #141 is merged first, or #141 should change `source(true)` to `source` if this is merged first.  (Or shepmaster can edit one while merging, I suppose.)