### PR TITLE
Error when source/backtrace(false) given on wrong field

### DIFF
--- a/compatibility-tests/compile-fail/tests/ui/attribute-misuse-opt-out-wrong-field.rs
+++ b/compatibility-tests/compile-fail/tests/ui/attribute-misuse-opt-out-wrong-field.rs
@@ -1,0 +1,25 @@
+mod source {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    enum EnumError {
+        AVariant {
+            #[snafu(source(false))]
+            not_source: u8,
+        },
+    }
+}
+
+mod backtrace {
+    use snafu::Snafu;
+
+    #[derive(Debug, Snafu)]
+    enum EnumError {
+        AVariant {
+            #[snafu(backtrace(false))]
+            not_backtrace: u8,
+        },
+    }
+}
+
+fn main() {}

--- a/compatibility-tests/compile-fail/tests/ui/attribute-misuse-opt-out-wrong-field.stderr
+++ b/compatibility-tests/compile-fail/tests/ui/attribute-misuse-opt-out-wrong-field.stderr
@@ -1,0 +1,11 @@
+error: `source(false)` attribute is only valid on a field named "source", not on other fields
+ --> $DIR/attribute-misuse-opt-out-wrong-field.rs:7:21
+  |
+7 |             #[snafu(source(false))]
+  |                     ^^^^^^^^^^^^^
+
+error: `backtrace(false)` attribute is only valid on a field named "backtrace", not on other fields
+  --> $DIR/attribute-misuse-opt-out-wrong-field.rs:19:21
+   |
+19 |             #[snafu(backtrace(false))]
+   |                     ^^^^^^^^^^^^^^^^

--- a/compatibility-tests/compile-fail/tests/ui/attribute-misuse.rs
+++ b/compatibility-tests/compile-fail/tests/ui/attribute-misuse.rs
@@ -34,7 +34,7 @@ mod field_misuse {
             #[snafu(visibility(pub))]
             #[snafu(source(false))]
             #[snafu(source(from(XXXX, Box::new)))]
-            a: String,
+            source: String,
         },
     }
 }

--- a/snafu-derive/src/lib.rs
+++ b/snafu-derive/src/lib.rs
@@ -526,8 +526,17 @@ fn parse_snafu_enum(
                                         }
                                         if v {
                                             source_attrs.add(None, tts.clone());
-                                        } else {
+                                        } else if name == "source" {
                                             source_opt_out = true;
+                                        } else {
+                                            errors.add(
+                                                tts.clone(),
+                                                OnlyValidOn {
+                                                    attribute: "source(false)",
+                                                    valid_on: "a field named \"source\"",
+                                                    not_on: "other fields",
+                                                },
+                                            );
                                         }
                                     }
                                     Source::From(t, e) => {
@@ -548,8 +557,17 @@ fn parse_snafu_enum(
                         SnafuAttribute::Backtrace(tts, v) => {
                             if v {
                                 backtrace_attrs.add((), tts);
-                            } else {
+                            } else if name == "backtrace" {
                                 backtrace_opt_out = true;
+                            } else {
+                                errors.add(
+                                    tts,
+                                    OnlyValidOn {
+                                        attribute: "backtrace(false)",
+                                        valid_on: "a field named \"backtrace\"",
+                                        not_on: "other fields",
+                                    },
+                                );
                             }
                         }
                         SnafuAttribute::Visibility(tts, ..) => {


### PR DESCRIPTION
Fixes #140

This adds errors for specifying `source(false)` on fields not named "source", and `backtrace(false)` on fields not named "backtrace".  These almost surely represent the user being confused about their purpose, and these error messages can help explain.

---

**Testing done:**

New compile-fail tests were added to show the errors in action.

Note: the `attribute-misuse.rs` compile-fail test was also updated because... it was using `source(false)` in this incorrect manner :)