### PR TITLE
Document context selectors and mention semver breakage when exporting them

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,6 +19,8 @@ stable_test_task:
     - cargo test --manifest-path compatibility-tests/without-backtrace/Cargo.toml
   futures_0.1_test_script:
     - cargo test --manifest-path compatibility-tests/futures-0.1/Cargo.toml
+  context_selectors_have_documentation_test_script:
+    - cargo test --manifest-path compatibility-tests/context-selectors-have-documentation/Cargo.toml
   compile_fail_test_script:
     - cargo test --manifest-path compatibility-tests/compile-fail/Cargo.toml
   lint_script:

--- a/compatibility-tests/context-selectors-have-documentation/Cargo.toml
+++ b/compatibility-tests/context-selectors-have-documentation/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "context-selectors-have-documentation"
+version = "0.1.0"
+authors = ["Jake Goulding <jake.goulding@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+snafu = { path = "../.." }

--- a/compatibility-tests/context-selectors-have-documentation/src/lib.rs
+++ b/compatibility-tests/context-selectors-have-documentation/src/lib.rs
@@ -1,0 +1,13 @@
+#![deny(missing_docs)]
+
+//! Crate docs
+
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub")]
+/// Enum docs
+pub enum Error {
+    /// Variant docs
+    Variant,
+}

--- a/src/guide/attributes.md
+++ b/src/guide/attributes.md
@@ -84,6 +84,11 @@ enum Error {
 }
 ```
 
+It should be noted that API stability of context selectors is not
+guaranteed. Therefore, exporting them in a crate's public API
+could cause semver breakage for such crates, should SNAFU internals
+change.
+
 ## Controlling error sources
 
 ### Selecting the source field


### PR DESCRIPTION
This PR generates some default documentation for SNAFU context selector types and adds a mention of possible semver breakage in the user guide, in the section discussing the visibility attribute.

I'm opening this already, so that we can discuss and improve the wording of the documentation enhancements if needed. I'll deal with generating the documentation when I have the time to dive into `snafu-derive`, hopefully later this week.

Closes #168  
Closes #170 