### PR TITLE
Add support for standard library std::backtrace::Backtrace

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -56,6 +56,8 @@ nightly_test_task:
     fingerprint_script: cat Cargo.toml
   primary_test_script:
     - cargo +nightly test
+  std_backtrace_test_script:
+    - RUST_BACKTRACE=1 cargo +nightly test --manifest-path compatibility-tests/backtraces-impl-std/Cargo.toml
   minimum_version_test_script:
     - cargo +nightly -Z minimal-versions update
     # These versions determined by trial and error

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,10 @@ backtraces = ["std", "backtrace"]
 # The backtrace type becomes `backtrace::Backtrace`
 backtraces-impl-backtrace-crate = ["backtraces"]
 
+# The backtrace type becomes `std::backtrace::Backtrace` and we
+# implement `std::error::Error::backtrace`
+unstable-backtraces-impl-std = ["backtraces", "snafu-derive/unstable-backtraces-impl-std"]
+
 # Add extension traits for the futures 0.1 crate
 "futures-01" = ["futures01"]
 

--- a/compatibility-tests/backtraces-impl-std/Cargo.toml
+++ b/compatibility-tests/backtraces-impl-std/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "backtraces-impl-std"
+version = "0.1.0"
+authors = ["Jake Goulding <jake.goulding@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+snafu = { path = "../..", features = ["unstable-backtraces-impl-std"] }

--- a/compatibility-tests/backtraces-impl-std/rust-toolchain
+++ b/compatibility-tests/backtraces-impl-std/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/compatibility-tests/backtraces-impl-std/src/lib.rs
+++ b/compatibility-tests/backtraces-impl-std/src/lib.rs
@@ -1,0 +1,38 @@
+#![cfg(test)]
+#![feature(backtrace)]
+
+use snafu::{Backtrace, ErrorCompat, Snafu};
+
+#[derive(Debug, Snafu)]
+enum Error {
+    WithBacktrace { backtrace: Backtrace },
+}
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+fn example() -> Result<()> {
+    WithBacktrace.fail()
+}
+
+#[test]
+fn is_compatible_with_std_error_trait() {
+    fn expects_std_trait<E: std::error::Error>() {}
+
+    expects_std_trait::<Error>();
+}
+
+#[test]
+fn is_compatible_with_std_backtrace_type() {
+    fn expects_std_type(_: &std::backtrace::Backtrace) {}
+
+    let error = example().unwrap_err();
+    let backtrace = ErrorCompat::backtrace(&error).unwrap();
+    expects_std_type(&backtrace);
+}
+
+#[test]
+fn backtrace_contains_function_names() {
+    let error = example().unwrap_err();
+    let backtrace = ErrorCompat::backtrace(&error).unwrap();
+    assert!(backtrace.to_string().contains("::example"));
+}

--- a/snafu-derive/Cargo.toml
+++ b/snafu-derive/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/shepmaster/snafu"
 
 license = "MIT OR Apache-2.0"
 
+[features]
+unstable-backtraces-impl-std = []
+
 [lib]
 proc-macro = true
 

--- a/snafu-derive/src/lib.rs
+++ b/snafu-derive/src/lib.rs
@@ -1560,6 +1560,16 @@ impl<'a> quote::ToTokens for ErrorImpl<'a> {
             }
         };
 
+        let std_backtrace_fn = if cfg!(feature = "unstable-backtraces-impl-std") {
+            quote! {
+                fn backtrace(&self) -> Option<&std::backtrace::Backtrace> {
+                    snafu::ErrorCompat::backtrace(self)
+                }
+            }
+        } else {
+            quote! {}
+        };
+
         stream.extend({
             quote! {
                 impl<#(#original_generics),*> snafu::Error for #parameterized_enum_name
@@ -1570,6 +1580,7 @@ impl<'a> quote::ToTokens for ErrorImpl<'a> {
                     #description_fn
                     #cause_fn
                     #source_fn
+                    #std_backtrace_fn
                 }
             }
         })
@@ -1690,6 +1701,16 @@ impl StructInfo {
             }
         };
 
+        let std_backtrace_fn = if cfg!(feature = "unstable-backtraces-impl-std") {
+            quote! {
+                fn backtrace(&self) -> Option<&std::backtrace::Backtrace> {
+                    snafu::ErrorCompat::backtrace(self)
+                }
+            }
+        } else {
+            quote! {}
+        };
+
         let error_impl = quote! {
             impl#generics snafu::Error for #parameterized_struct_name
             where
@@ -1698,6 +1719,7 @@ impl StructInfo {
                 #description_fn
                 #cause_fn
                 #source_fn
+                #std_backtrace_fn
             }
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(missing_docs)]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
+#![cfg_attr(feature = "unstable-backtraces-impl-std", feature(backtrace))]
 
 //! # SNAFU
 //!
@@ -78,27 +79,34 @@
 #[cfg(all(
     not(feature = "backtraces"),
     not(feature = "backtraces-impl-backtrace-crate"),
+    not(feature = "unstable-backtraces-impl-std"),
 ))]
 mod backtrace_inert;
 #[cfg(all(
     not(feature = "backtraces"),
     not(feature = "backtraces-impl-backtrace-crate"),
+    not(feature = "unstable-backtraces-impl-std"),
 ))]
 pub use crate::backtrace_inert::*;
 
 #[cfg(all(
     feature = "backtraces",
     not(feature = "backtraces-impl-backtrace-crate"),
+    not(feature = "unstable-backtraces-impl-std"),
 ))]
 mod backtrace_shim;
 #[cfg(all(
     feature = "backtraces",
     not(feature = "backtraces-impl-backtrace-crate"),
+    not(feature = "unstable-backtraces-impl-std"),
 ))]
 pub use crate::backtrace_shim::*;
 
 #[cfg(feature = "backtraces-impl-backtrace-crate")]
 pub use backtrace::Backtrace;
+
+#[cfg(feature = "unstable-backtraces-impl-std")]
+pub use std::backtrace::Backtrace;
 
 #[cfg(feature = "futures-01")]
 pub mod futures01;
@@ -625,6 +633,17 @@ impl GenerateBacktrace for Option<Backtrace> {
 impl GenerateBacktrace for Backtrace {
     fn generate() -> Self {
         Backtrace::new()
+    }
+
+    fn as_backtrace(&self) -> Option<&Backtrace> {
+        Some(self)
+    }
+}
+
+#[cfg(feature = "unstable-backtraces-impl-std")]
+impl GenerateBacktrace for Backtrace {
+    fn generate() -> Self {
+        Backtrace::force_capture()
     }
 
     fn as_backtrace(&self) -> Option<&Backtrace> {


### PR DESCRIPTION
See #172. This gives a proper `.backtrace()` to snafu errors, using nightly's `#![feature(backtrace)]`.

When enabled, this re-exports `std::backtrace::Backtrace` as `snafu::Backtrace` and changes `snafu::ErrorCompat::backtrace` such that it returns a std library backtrace instead of one from the `backtrace` crate.

May be a bit messy, as I haven't contributed to this project before. There are some considerations that need to be decided (see git commit comments) before this is merged, so I'm leaving it as a draft.