### PR TITLE
Make ensure! macro work with opaque error types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ use std::error;
 macro_rules! ensure {
     ($predicate:expr, $context_selector:expr) => {
         if !$predicate {
-            return $context_selector.fail();
+            return $context_selector.fail().map_err(core::convert::Into::into);
         }
     };
 }


### PR DESCRIPTION
fixes #175