### PR TITLE
feat: `allow(single_use_lifetimes)` where applicable

### DIFF
--- a/snafu-derive/src/lib.rs
+++ b/snafu-derive/src/lib.rs
@@ -1564,6 +1564,7 @@ impl<'a> quote::ToTokens for DisplayImpl<'a> {
 
         stream.extend({
             quote! {
+                #[allow(single_use_lifetimes)]
                 impl<#(#original_generics),*> core::fmt::Display for #parameterized_enum_name
                 where
                     #(#where_clauses),*
@@ -1683,6 +1684,7 @@ impl<'a> quote::ToTokens for ErrorImpl<'a> {
 
         stream.extend({
             quote! {
+                #[allow(single_use_lifetimes)]
                 impl<#(#original_generics),*> snafu::Error for #parameterized_enum_name
                 where
                     Self: core::fmt::Debug + core::fmt::Display,
@@ -1757,6 +1759,7 @@ impl<'a> quote::ToTokens for ErrorCompatImpl<'a> {
 
         stream.extend({
             quote! {
+                #[allow(single_use_lifetimes)]
                 impl<#(#original_generics),*> snafu::ErrorCompat for #parameterized_enum_name
                 where
                     #(#where_clauses),*
@@ -1822,6 +1825,7 @@ impl StructInfo {
         };
 
         let error_impl = quote! {
+            #[allow(single_use_lifetimes)]
             impl#generics snafu::Error for #parameterized_struct_name
             where
                 #(#where_clauses),*
@@ -1834,6 +1838,7 @@ impl StructInfo {
         };
 
         let error_compat_impl = quote! {
+            #[allow(single_use_lifetimes)]
             impl#generics snafu::ErrorCompat for #parameterized_struct_name
             where
                 #(#where_clauses),*
@@ -1843,6 +1848,7 @@ impl StructInfo {
         };
 
         let display_impl = quote! {
+            #[allow(single_use_lifetimes)]
             impl#generics core::fmt::Display for #parameterized_struct_name
             where
                 #(#where_clauses),*

--- a/tests/single_use_lifetimes_lint.rs
+++ b/tests/single_use_lifetimes_lint.rs
@@ -1,0 +1,17 @@
+#![deny(single_use_lifetimes)]
+
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+pub enum Enum<'id> {
+    #[snafu(display("`{}` is foo, yo", to))]
+    Foo { to: &'id u32 },
+    #[snafu(display("bar `{}` frobnicated `{}`", from, to))]
+    Bar { from: &'id String, to: &'id i8 },
+}
+
+#[derive(Debug, Snafu)]
+pub struct Struct<'id>(Enum<'id>);
+
+#[test]
+fn it_compiles() {}


### PR DESCRIPTION
Users can run into an issue compiling code if their project uses `#[deny(single_use_lifetimes)]` for some reasonable error definitions. This attempts to alleviate that.