### PR TITLE
Update Backtrace documentation

### DIFF
--- a/src/backtrace_shim.rs
+++ b/src/backtrace_shim.rs
@@ -3,8 +3,8 @@ use std::{fmt, path};
 
 /// A backtrace starting from the beginning of the thread.
 ///
-/// Backtrace functionality is currently **enabled**. Please review
-/// [the feature flags](crate::guide::feature_flags) to disable it.
+/// Backtrace functionality is currently **diabled**. Please review
+/// [the feature flags](crate::guide::feature_flags) to enable it.
 #[derive(Debug)]
 pub struct Backtrace(backtrace::Backtrace);
 


### PR DESCRIPTION
The guide has the backtraces feature listed as disabled, and it seems the inline documentation fell out of date. Just it case, it'd be a good idea to review similar places in the documentation.

Either that, or find a way to verify it? Maybe a doctest could force the explanation to keep up to date.