### PR TITLE
Allow optional trailing commas in `ensure!`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,7 +196,7 @@ pub use no_std_error::Error;
 /// ```
 #[macro_export]
 macro_rules! ensure {
-    ($predicate:expr, $context_selector:expr) => {
+    ($predicate:expr, $context_selector:expr $(,)*) => {
         if !$predicate {
             return $context_selector.fail().map_err(core::convert::Into::into);
         }

--- a/tests/ensure.rs
+++ b/tests/ensure.rs
@@ -1,0 +1,22 @@
+use snafu::{ensure, Snafu};
+
+#[derive(Debug, Snafu)]
+enum Error {
+    AVeryLongVariantName { a_long_piece_of_information: i32 },
+}
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[test]
+fn accepts_trailing_commas() {
+    fn example(a_long_piece_of_information: i32) -> Result<()> {
+        ensure!(
+            a_long_piece_of_information > a_long_piece_of_information - 1,
+            AVeryLongVariantName {
+                a_long_piece_of_information,
+            },
+        );
+        Ok(())
+    }
+    let _ = example(42);
+}


### PR DESCRIPTION
Fixes #243