### PR TITLE
Disambiguate references to the core library from the ensure macro

### DIFF
--- a/compatibility-tests/v1_31/Cargo.toml
+++ b/compatibility-tests/v1_31/Cargo.toml
@@ -9,3 +9,4 @@ snafu = { path = "../..", default-features = false, features = ["backtraces"] }
 
 # These versions are the last versions to support Rust 1.31
 backtrace = "= 0.3.35"
+cc = "= 1.0.61"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,9 @@ pub use no_std_error::Error;
 macro_rules! ensure {
     ($predicate:expr, $context_selector:expr $(,)*) => {
         if !$predicate {
-            return $context_selector.fail().map_err(core::convert::Into::into);
+            return $context_selector
+                .fail()
+                .map_err(::core::convert::Into::into);
         }
     };
 }

--- a/tests/name-conflicts.rs
+++ b/tests/name-conflicts.rs
@@ -1,4 +1,4 @@
-use snafu::Snafu;
+use snafu::{ensure, Snafu};
 
 // Modules to clash with likely candidates from the standard library.
 mod core {}
@@ -22,4 +22,9 @@ enum VariantNamedOk<T> {
 #[derive(Debug, Snafu)]
 enum VariantNamedErr<T> {
     Err { value: T },
+}
+
+fn _using_ensure() -> Result<u8, VariantNamedNone> {
+    ensure!(false, None);
+    Ok(0)
 }


### PR DESCRIPTION
Fixes #270