### PR TITLE
Implement #[snafu(module)] support

### DIFF
--- a/compatibility-tests/compile-fail/tests/ui/module-visibility.rs
+++ b/compatibility-tests/compile-fail/tests/ui/module-visibility.rs
@@ -1,0 +1,19 @@
+mod inside {
+    use snafu::prelude::*;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(module)]
+    enum Error {
+        Variant,
+    }
+
+    fn can_access_in_same_module() {
+        let _ = error::VariantSnafu;
+    }
+}
+
+fn cant_access_outside_of_module() {
+    let _ = inside::error::VariantSnafu;
+}
+
+fn main() {}

--- a/compatibility-tests/compile-fail/tests/ui/module-visibility.stderr
+++ b/compatibility-tests/compile-fail/tests/ui/module-visibility.stderr
@@ -1,0 +1,12 @@
+error[E0603]: module `error` is private
+  --> $DIR/module-visibility.rs:16:21
+   |
+16 |     let _ = inside::error::VariantSnafu;
+   |                     ^^^^^ private module
+   |
+note: the module `error` is defined here
+  --> $DIR/module-visibility.rs:4:21
+   |
+4  |     #[derive(Debug, Snafu)]
+   |                     ^^^^^
+   = note: this error originates in the derive macro `Snafu` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/compatibility-tests/compile-fail/tests/ui/structs/attribute-misuse.stderr
+++ b/compatibility-tests/compile-fail/tests/ui/structs/attribute-misuse.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `backtrace`, `context`, `crate_root`, `display`, `implicit`, `source`, `visibility`, `whatever`
+error: expected one of: `backtrace`, `context`, `crate_root`, `display`, `implicit`, `module`, `source`, `visibility`, `whatever`
  --> $DIR/attribute-misuse.rs:5:13
   |
 5 |     #[snafu(unknown_attribute)]

--- a/snafu-derive/Cargo.toml
+++ b/snafu-derive/Cargo.toml
@@ -21,3 +21,4 @@ proc-macro = true
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
+heck = "0.3.3"

--- a/tests/module.rs
+++ b/tests/module.rs
@@ -1,0 +1,102 @@
+pub mod inner {
+    use snafu::Snafu;
+
+    #[derive(Debug)]
+    pub struct Dummy0;
+
+    #[derive(Debug)]
+    pub struct Dummy1;
+
+    #[derive(Debug)]
+    pub struct Dummy2;
+
+    #[derive(Debug)]
+    pub struct Dummy3;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(module, visibility(pub))]
+    pub enum PubError {
+        Variant { v: Dummy0 },
+    }
+
+    #[derive(Debug, Snafu)]
+    #[snafu(module(custom_pub), visibility(pub))]
+    pub enum PubWithCustomModError {
+        Variant { v: Dummy1 },
+    }
+
+    #[derive(Debug, Snafu)]
+    #[snafu(module(custom_pub_crate), visibility(pub(crate)))]
+    pub(crate) enum PubCrateWithCustomModError {
+        Variant { v: Dummy2 },
+    }
+
+    mod child {
+        use super::Dummy3;
+        use snafu::Snafu;
+
+        #[derive(Debug, Snafu)]
+        #[snafu(module, visibility(pub(in crate::inner)))]
+        pub enum RestrictedError {
+            Variant { v: Dummy3 },
+        }
+    }
+
+    #[test]
+    fn can_set_module_visibility_restricted() {
+        let _ = self::child::restricted_error::VariantSnafu { v: Dummy3 }.build();
+    }
+}
+
+use self::inner::Dummy1;
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(module)]
+pub enum SomeError {
+    Variant { v: i32 },
+}
+
+#[derive(Debug, Snafu)]
+#[snafu(module)]
+pub enum QualifiedError {
+    Variant {
+        unqualified: Dummy1,
+        mod_struct: inner::Dummy0,
+        self_struct: self::Dummy1,
+        crate_struct: crate::Dummy1,
+        boxed_trait: Box<dyn ::core::any::Any>,
+    },
+}
+
+#[test]
+fn can_use_qualified_names_in_module() {
+    let _ = qualified_error::VariantSnafu {
+        unqualified: Dummy1,
+        mod_struct: inner::Dummy0,
+        self_struct: self::Dummy1,
+        crate_struct: crate::Dummy1,
+        boxed_trait: Box::new(()) as Box<_>,
+    }
+    .build();
+}
+
+#[test]
+fn can_set_module() {
+    let _ = some_error::VariantSnafu { v: 0i32 }.build();
+}
+
+#[test]
+fn can_set_module_visibility_pub() {
+    let _ = inner::pub_error::VariantSnafu { v: inner::Dummy0 }.build();
+}
+
+#[test]
+fn can_set_module_visibility_pub_with_custom_name() {
+    let _ = inner::custom_pub::VariantSnafu { v: inner::Dummy1 }.build();
+}
+
+#[test]
+fn can_set_module_visibility_pub_crate_with_custom_name() {
+    let _ = inner::custom_pub_crate::VariantSnafu { v: inner::Dummy2 }.build();
+}

--- a/tests/structs/main.rs
+++ b/tests/structs/main.rs
@@ -7,6 +7,7 @@ mod context_selector_name;
 mod display;
 mod from_option;
 mod generics;
+mod module;
 mod no_context;
 mod single_use_lifetimes;
 mod source_attributes;

--- a/tests/structs/module.rs
+++ b/tests/structs/module.rs
@@ -1,0 +1,79 @@
+pub mod inner {
+    use snafu::Snafu;
+
+    #[derive(Debug)]
+    pub struct Dummy0;
+
+    #[derive(Debug)]
+    pub struct Dummy1;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(module, visibility(pub))]
+    pub struct PubError;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(module(custom_pub), visibility(pub))]
+    pub struct PubWithCustomModError;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(module(custom_pub_crate), visibility(pub(crate)))]
+    pub(crate) struct PubCrateWithCustomModError;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(module, visibility(pub(in crate::module)))]
+    pub struct RestrictedError;
+}
+
+use self::inner::Dummy1;
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(module)]
+pub struct SomeError;
+
+#[derive(Debug, Snafu)]
+#[snafu(module)]
+pub struct QualifiedError {
+    unqualified: Dummy1,
+    mod_struct: inner::Dummy0,
+    self_struct: self::Dummy1,
+    crate_struct: crate::module::Dummy1,
+    boxed_trait: Box<dyn ::core::any::Any>,
+}
+
+#[test]
+fn can_use_qualified_names_in_module() {
+    let _ = qualified_error::QualifiedSnafu {
+        unqualified: Dummy1,
+        mod_struct: inner::Dummy0,
+        self_struct: self::Dummy1,
+        crate_struct: crate::module::Dummy1,
+        boxed_trait: Box::new(()) as Box<_>,
+    }
+    .build();
+}
+
+#[test]
+fn can_set_module() {
+    let _ = some_error::SomeSnafu.build();
+}
+
+#[test]
+fn can_set_module_visibility_pub() {
+    let _ = inner::pub_error::PubSnafu.build();
+}
+
+#[test]
+fn can_set_module_visibility_restricted() {
+    let _ = inner::restricted_error::RestrictedSnafu.build();
+}
+
+#[test]
+fn can_set_module_visibility_pub_with_custom_name() {
+    let _ = inner::custom_pub::PubWithCustomModSnafu.build();
+}
+
+#[test]
+fn can_set_module_visibility_pub_crate_with_custom_name() {
+    let _ = inner::custom_pub_crate::PubCrateWithCustomModSnafu.build();
+}


### PR DESCRIPTION
Here's a rough first pass at implementing submodule support. This is my first time in proc-macro land, so apologies if anything is implemented horribly!

There are a couple points that I wanted to discuss before doing too much more work:

 - Like @shepmaster mentioned in #286, `super::` is problematic; would checking for `super`, and just prepending another `super` be _Good Enough™_ ? I _think_ a similar prepend `super` approach would work for visibility too (possibly adding `in`).
 
 - The visibility of types inside the module has to be at least as restrictive as the module itself, which seems to work the way I have it now, but I'd like another pair of eyes to take a look.
 
 - I've somewhat overloaded the `visibility` attribute to control both the module and the types in the module (to "solve" the previous point.) Would there be much value in controlling the visibility of types in the module separately from the module itself, and if so, how would you like it to look?
 
 - Would you be horribly opposed to clearing the suffix (by default) if `module` is enabled?