### PR TITLE
Allow iter_chain to be used on no_std

### DIFF
--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -4,18 +4,18 @@
 ///
 /// Can be created via [`ErrorCompat::iter_chain`][crate::ErrorCompat::iter_chain].
 pub struct ChainCompat<'a> {
-    inner: Option<&'a dyn std::error::Error>,
+    inner: Option<&'a dyn crate::Error>,
 }
 
 impl<'a> ChainCompat<'a> {
     /// Creates a new error chain iterator.
-    pub fn new(error: &'a dyn std::error::Error) -> Self {
+    pub fn new(error: &'a dyn crate::Error) -> Self {
         ChainCompat { inner: Some(error) }
     }
 }
 
 impl<'a> Iterator for ChainCompat<'a> {
-    type Item = &'a dyn std::error::Error;
+    type Item = &'a dyn crate::Error;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.inner {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,9 +252,7 @@ pub use std::backtrace::Backtrace;
 #[cfg(feature = "futures")]
 pub mod futures;
 
-#[cfg(feature = "std")]
 mod error_chain;
-#[cfg(feature = "std")]
 pub use crate::error_chain::*;
 
 doc_comment::doc_comment! {
@@ -969,7 +967,6 @@ pub trait ErrorCompat {
     ///
     /// To omit the current error and only traverse its sources,
     /// use `skip(1)`.
-    #[cfg(feature = "std")]
     fn iter_chain(&self) -> ChainCompat
     where
         Self: AsErrorSource,


### PR DESCRIPTION
Hello!

This change will allow `no_std` users of snafu to make use of snafu's `ErrorCompat::iter_chain` function. Usage remains exactly the same as before.

I could not figure out an easy way to write an automatic test for this since the cargo test harness needs `std` (hence the `test` portion of these cfg attributes which already exist in the codebase `#[cfg(not(any(feature = "std", test)))]`)

 Here is the code I have used to test whether the feature works or not: https://github.com/OliverUv/snafu_api_experiment - it is a little larger than a minimal example since it also contains a small experiment to hack in dyn trait source errors. The relevant code is L114-157 of main.rs ( https://github.com/OliverUv/snafu_api_experiment/blob/7127727fb6a2efe6ecaa85c292309dfaff9e0aa9/src/main.rs#L114 )