### PR TITLE
Add GenerateImplicitData::generate_with_source

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -145,6 +145,10 @@ nightly_test_task:
     - cd compatibility-tests/report-try-trait/
     - rustc --version
     - cargo test
+  report_provider_api_test_script:
+    - cd compatibility-tests/backtrace-provider-api/
+    - rustc --version
+    - cargo test
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 unstable_std_backtraces_test_task:

--- a/compatibility-tests/backtrace-provider-api/Cargo.toml
+++ b/compatibility-tests/backtrace-provider-api/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "backtrace-provider-api"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+snafu = { path = "../..", features = ["unstable-provider-api"] }

--- a/compatibility-tests/backtrace-provider-api/rust-toolchain
+++ b/compatibility-tests/backtrace-provider-api/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/compatibility-tests/backtrace-provider-api/src/lib.rs
+++ b/compatibility-tests/backtrace-provider-api/src/lib.rs
@@ -1,0 +1,44 @@
+#![cfg(test)]
+#![feature(error_generic_member_access, provide_any)]
+
+use snafu::{prelude::*, IntoError};
+
+#[test]
+fn does_not_capture_a_backtrace_when_source_provides_a_backtrace() {
+    #[derive(Debug, Snafu)]
+    struct InnerError {
+        backtrace: snafu::Backtrace,
+    }
+
+    #[derive(Debug, Snafu)]
+    struct OuterError {
+        source: InnerError,
+        backtrace: Option<snafu::Backtrace>,
+    }
+
+    enable_backtrace_capture();
+    let e = OuterSnafu.into_error(InnerSnafu.build());
+
+    assert!(e.backtrace.is_none());
+}
+
+#[test]
+fn does_capture_a_backtrace_when_source_does_not_provide_a_backtrace() {
+    #[derive(Debug, Snafu)]
+    struct InnerError;
+
+    #[derive(Debug, Snafu)]
+    struct OuterError {
+        source: InnerError,
+        backtrace: Option<snafu::Backtrace>,
+    }
+
+    enable_backtrace_capture();
+    let e = OuterSnafu.into_error(InnerSnafu.build());
+
+    assert!(e.backtrace.is_some());
+}
+
+fn enable_backtrace_capture() {
+    std::env::set_var("RUST_LIB_BACKTRACE", "1");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1138,6 +1138,16 @@ pub trait FromString {
 pub trait GenerateImplicitData {
     /// Build the data.
     fn generate() -> Self;
+
+    /// Build the data using the given source
+    #[cfg_attr(feature = "rust_1_46", track_caller)]
+    fn generate_with_source(source: &dyn crate::Error) -> Self
+    where
+        Self: Sized,
+    {
+        let _source = source;
+        Self::generate()
+    }
 }
 
 /// View a backtrace-like value as an optional backtrace.


### PR DESCRIPTION
This allows implicit data to inspect underlying error causes to avoid creating redundant data. It also uses that for `Option<Backtrace>` when the provider API is enabled.

Closes #349