### PR TITLE
Uniformly use the transformed error source in the error constructor

### DIFF
--- a/snafu-derive/src/lib.rs
+++ b/snafu-derive/src/lib.rs
@@ -194,15 +194,20 @@ impl SourceField {
 }
 
 enum Transformation {
-    None { ty: syn::Type },
-    Transform { ty: syn::Type, expr: syn::Expr },
+    None {
+        ty: syn::Type,
+    },
+    Transform {
+        source_ty: syn::Type,
+        expr: syn::Expr,
+    },
 }
 
 impl Transformation {
-    fn ty(&self) -> &syn::Type {
+    fn source_ty(&self) -> &syn::Type {
         match self {
             Transformation::None { ty } => ty,
-            Transformation::Transform { ty, .. } => ty,
+            Transformation::Transform { source_ty, .. } => source_ty,
         }
     }
 
@@ -936,7 +941,7 @@ fn field_container(
                 name, ty, provide, ..
             } = field;
             let transformation = maybe_transformation
-                .map(|(ty, expr)| Transformation::Transform { ty, expr })
+                .map(|(source_ty, expr)| Transformation::Transform { source_ty, expr })
                 .unwrap_or_else(|| Transformation::None { ty });
 
             source_fields.add(
@@ -1239,7 +1244,7 @@ fn parse_snafu_tuple_struct(
 
     let (maybe_transformation, errs) = transformations.finish();
     let transformation = maybe_transformation
-        .map(|(ty, expr)| Transformation::Transform { ty, expr })
+        .map(|(source_ty, expr)| Transformation::Transform { source_ty, expr })
         .unwrap_or_else(|| Transformation::None {
             ty: inner.into_value().ty,
         });
@@ -1878,7 +1883,7 @@ impl TupleStructInfo {
             provides,
         } = self;
 
-        let inner_type = transformation.ty();
+        let inner_type = transformation.source_ty();
         let transformation = transformation.transformation();
 
         let where_clauses: Vec<_> = generics

--- a/snafu-derive/src/lib.rs
+++ b/snafu-derive/src/lib.rs
@@ -199,6 +199,7 @@ enum Transformation {
     },
     Transform {
         source_ty: syn::Type,
+        target_ty: syn::Type,
         expr: syn::Expr,
     },
 }
@@ -208,6 +209,13 @@ impl Transformation {
         match self {
             Transformation::None { ty } => ty,
             Transformation::Transform { source_ty, .. } => source_ty,
+        }
+    }
+
+    fn target_ty(&self) -> &syn::Type {
+        match self {
+            Transformation::None { ty } => ty,
+            Transformation::Transform { target_ty, .. } => target_ty,
         }
     }
 
@@ -941,7 +949,11 @@ fn field_container(
                 name, ty, provide, ..
             } = field;
             let transformation = maybe_transformation
-                .map(|(source_ty, expr)| Transformation::Transform { source_ty, expr })
+                .map(|(source_ty, expr)| Transformation::Transform {
+                    source_ty,
+                    target_ty: ty.clone(),
+                    expr,
+                })
                 .unwrap_or_else(|| Transformation::None { ty });
 
             source_fields.add(
@@ -1242,12 +1254,15 @@ fn parse_snafu_tuple_struct(
         return Err(vec![one_field_error(span)]);
     }
 
+    let ty = inner.into_value().ty;
     let (maybe_transformation, errs) = transformations.finish();
     let transformation = maybe_transformation
-        .map(|(source_ty, expr)| Transformation::Transform { source_ty, expr })
-        .unwrap_or_else(|| Transformation::None {
-            ty: inner.into_value().ty,
-        });
+        .map(|(source_ty, expr)| Transformation::Transform {
+            source_ty,
+            target_ty: ty.clone(),
+            expr,
+        })
+        .unwrap_or_else(|| Transformation::None { ty });
     errors.extend(errs);
 
     let (maybe_crate_root, errs) = crate_roots.finish();

--- a/snafu-derive/src/shared.rs
+++ b/snafu-derive/src/shared.rs
@@ -360,7 +360,7 @@ pub mod context_selector {
 
             let (source_ty, transfer_source_field, empty_source_field) = match source_field {
                 Some(f) => {
-                    let source_field_type = f.transformation.ty();
+                    let source_field_type = f.transformation.source_ty();
                     let source_field_name = &f.name;
                     let source_transformation = f.transformation.transformation();
 
@@ -435,7 +435,7 @@ pub mod context_selector {
     // Assumes that the error is in a variable called "error"
     fn build_source_info(source_field: &crate::SourceField) -> (&syn::Type, TokenStream) {
         let source_field_name = source_field.name();
-        let source_field_type = source_field.transformation.ty();
+        let source_field_type = source_field.transformation.source_ty();
         let source_transformation = source_field.transformation.transformation();
 
         (
@@ -750,7 +750,8 @@ pub mod error {
                 .source_field()
                 .filter(|f| f.provide);
 
-            let source_provide_ref = provided_source.map(|f| (f.transformation.ty(), f.name()));
+            let source_provide_ref =
+                provided_source.map(|f| (f.transformation.source_ty(), f.name()));
 
             let provide_refs = provide_refs.chain(source_provide_ref);
 

--- a/tests/implicit.rs
+++ b/tests/implicit.rs
@@ -157,3 +157,34 @@ mod with_and_without_source {
         assert_eq!(e.data.0, ItWas::GenerateWithSource);
     }
 }
+
+mod converted_sources {
+    use snafu::{prelude::*, IntoError};
+
+    #[derive(Debug)]
+    struct ImplicitData;
+
+    impl snafu::GenerateImplicitData for ImplicitData {
+        fn generate() -> Self {
+            Self
+        }
+    }
+
+    #[derive(Debug, Snafu)]
+    struct HasSource {
+        backtrace: snafu::Backtrace,
+
+        #[snafu(implicit)]
+        data: ImplicitData,
+
+        #[snafu(source(from(String, Into::into)))]
+        source: Box<dyn std::error::Error>,
+    }
+
+    #[test]
+    fn receives_the_error_after_conversion() {
+        let e = HasSourceSnafu.into_error(String::from("bad"));
+        // Mostly testing that this compiles; assertion is bonus
+        assert_eq!(e.source.to_string(), "bad");
+    }
+}


### PR DESCRIPTION
Previously, we only converted the source in the source field initializer. However, `GenerateImplicitData::generate_with_source` also needs access to the post-converted value.

Fixes #364
