### PR TITLE
Migrate syn to v2

### DIFF
--- a/snafu-derive/Cargo.toml
+++ b/snafu-derive/Cargo.toml
@@ -20,7 +20,7 @@ unstable-provider-api = []
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.3", features = ["full"] }
-quote = "1.0"
-proc-macro2 = "1.0"
+syn = { version = "2.0", features = ["full"] }
+quote = "1.0.25"
+proc-macro2 = "1.0.52"
 heck = "0.4"

--- a/snafu-derive/src/lib.rs
+++ b/snafu-derive/src/lib.rs
@@ -1438,27 +1438,29 @@ trait GenericAwareNames {
     }
 
     fn provided_generic_lifetimes(&self) -> Vec<proc_macro2::TokenStream> {
-        use syn::{GenericParam, LifetimeDef};
+        use syn::{GenericParam, LifetimeParam};
 
         self.generics()
             .params
             .iter()
             .flat_map(|p| match p {
-                GenericParam::Lifetime(LifetimeDef { lifetime, .. }) => Some(quote! { #lifetime }),
+                GenericParam::Lifetime(LifetimeParam { lifetime, .. }) => {
+                    Some(quote! { #lifetime })
+                }
                 _ => None,
             })
             .collect()
     }
 
     fn provided_generic_names(&self) -> Vec<proc_macro2::TokenStream> {
-        use syn::{ConstParam, GenericParam, LifetimeDef, TypeParam};
+        use syn::{ConstParam, GenericParam, LifetimeParam, TypeParam};
 
         self.generics()
             .params
             .iter()
             .map(|p| match p {
                 GenericParam::Type(TypeParam { ident, .. }) => quote! { #ident },
-                GenericParam::Lifetime(LifetimeDef { lifetime, .. }) => quote! { #lifetime },
+                GenericParam::Lifetime(LifetimeParam { lifetime, .. }) => quote! { #lifetime },
                 GenericParam::Const(ConstParam { ident, .. }) => quote! { #ident },
             })
             .collect()


### PR DESCRIPTION
Resolves #379, but depends on #381. I am leaving the PR in advance so that it can be reviewed when the time is right.

### Summary

- change `LifetimeDef` to `LifetimeParam`
- change field access `path` to method call `path()`
- change `DocComment` to comply with meta attribute parsing
