### PR TITLE
Extract an iterator that cleans redundant nested error text

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,8 @@ mod error_chain;
 pub use crate::error_chain::*;
 
 mod report;
+#[cfg(feature = "std")]
+pub use report::CleanedErrorText;
 pub use report::{Report, __InternalExtractErrorType};
 
 doc_comment::doc_comment! {


### PR DESCRIPTION
This allows the cleaning logic to be reused in other contexts, such as an HTML or JSON error report.