### PR TITLE
Update compile_error test snapshots

### DIFF
--- a/compatibility-tests/compile-fail/tests/ui/structs/visibility.stderr
+++ b/compatibility-tests/compile-fail/tests/ui/structs/visibility.stderr
@@ -11,11 +11,11 @@ note: the unit struct `Snafu` is defined here
    |                     ^^^^^
    = note: this error originates in the derive macro `Snafu` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0624]: associated function `build` is private
+error[E0624]: method `build` is private
   --> tests/ui/structs/visibility.rs:11:26
    |
 6  |     #[derive(Debug, Snafu)]
-   |                     ----- private associated function defined here
+   |                     ----- private method defined here
 ...
 11 |     let _ = inner::Snafu.build();
-   |                          ^^^^^ private associated function
+   |                          ^^^^^ private method

--- a/compatibility-tests/compile-fail/tests/ui/visibility.stderr
+++ b/compatibility-tests/compile-fail/tests/ui/visibility.stderr
@@ -37,29 +37,29 @@ note: the unit struct `PrivateSnafu` is defined here
    |                         ^^^^^
    = note: this error originates in the derive macro `Snafu` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0624]: associated function `build` is private
+error[E0624]: method `build` is private
   --> tests/ui/visibility.rs:19:43
    |
 7  |         #[derive(Debug, Snafu)]
-   |                         ----- private associated function defined here
+   |                         ----- private method defined here
 ...
 19 |         let _ = self::inner::PrivateSnafu.build();
-   |                                           ^^^^^ private associated function
+   |                                           ^^^^^ private method
 
-error[E0624]: associated function `build` is private
+error[E0624]: method `build` is private
   --> tests/ui/visibility.rs:24:48
    |
 7  |         #[derive(Debug, Snafu)]
-   |                         ----- private associated function defined here
+   |                         ----- private method defined here
 ...
 24 |     let _ = self::outer::inner::PubInPathSnafu.build();
-   |                                                ^^^^^ private associated function
+   |                                                ^^^^^ private method
 
-error[E0624]: associated function `build` is private
+error[E0624]: method `build` is private
   --> tests/ui/visibility.rs:28:46
    |
 7  |         #[derive(Debug, Snafu)]
-   |                         ----- private associated function defined here
+   |                         ----- private method defined here
 ...
 28 |     let _ = self::outer::inner::PrivateSnafu.build();
-   |                                              ^^^^^ private associated function
+   |                                              ^^^^^ private method


### PR DESCRIPTION
Extracted this from #381 as requested.

### Summary

- Update `compile_error` test error message snapshots according to the latest stable toolchain, with changes caused by specialized referencing of methods
   - compatibility-tests/compile-fail/tests/ui
   - compatibility-tests/compile-fail/tests/structs