### PR TITLE
ChainCompat now returns &'a (dyn Error + 'b) to allow downcasting

### DIFF
--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -4,19 +4,19 @@
 ///
 /// Can be created via [`ErrorCompat::iter_chain`][crate::ErrorCompat::iter_chain].
 #[derive(Debug, Clone)]
-pub struct ChainCompat<'a> {
-    inner: Option<&'a dyn crate::Error>,
+pub struct ChainCompat<'a, 'b> {
+    inner: Option<&'a (dyn crate::Error + 'b)>,
 }
 
-impl<'a> ChainCompat<'a> {
+impl<'a, 'b> ChainCompat<'a, 'b> {
     /// Creates a new error chain iterator.
-    pub fn new(error: &'a dyn crate::Error) -> Self {
+    pub fn new(error: &'a (dyn crate::Error + 'b)) -> Self {
         ChainCompat { inner: Some(error) }
     }
 }
 
-impl<'a> Iterator for ChainCompat<'a> {
-    type Item = &'a dyn crate::Error;
+impl<'a, 'b> Iterator for ChainCompat<'a, 'b> {
+    type Item = &'a (dyn crate::Error + 'b);
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.inner {

--- a/tests/error_chain.rs
+++ b/tests/error_chain.rs
@@ -1,7 +1,7 @@
 use snafu::prelude::*;
 use std::fmt::Debug;
 
-#[derive(Debug, Clone, Snafu)]
+#[derive(Debug, Clone, Snafu, PartialEq)]
 enum LeafError {
     #[snafu(display("User ID {} is invalid", user_id))]
     InvalidUser { user_id: i32 },
@@ -9,13 +9,13 @@ enum LeafError {
     MissingUser,
 }
 
-#[derive(Debug, Clone, Snafu)]
+#[derive(Debug, Clone, Snafu, PartialEq)]
 enum MiddleError {
     #[snafu(display("failed to check the user"))]
     CheckUser { source: LeafError },
 }
 
-#[derive(Debug, Clone, Snafu)]
+#[derive(Debug, Clone, Snafu, PartialEq)]
 enum Error {
     #[snafu(display("access control failure"))]
     AccessControl { source: MiddleError },
@@ -54,4 +54,19 @@ fn errorcompat_chain_iterates() {
     assert_eq_debug(&errors[0], &error);
     assert_eq_debug(&errors[1], &middle_error);
     assert_eq_debug(&errors[2], &bottom_error);
+}
+
+#[test]
+fn can_downcast_chain_values() {
+    use snafu::{ChainCompat, IntoError};
+
+    let bottom_error = InvalidUserSnafu { user_id: 12 }.build();
+    let middle_error = CheckUserSnafu.into_error(bottom_error.clone());
+    let error = AccessControlSnafu.into_error(middle_error.clone());
+
+    let errors: Vec<_> = ChainCompat::new(&error).collect();
+
+    assert_eq!(Some(&error), errors[0].downcast_ref::<Error>());
+    assert_eq!(Some(&middle_error), errors[1].downcast_ref::<MiddleError>());
+    assert_eq!(Some(&bottom_error), errors[2].downcast_ref::<LeafError>());
 }


### PR DESCRIPTION
Previously it unconditionally returned &'a (dyn Error + 'a) which was never downcastable. The additional lifetime can be `'static`, resulting in `&'a (dyn Error + 'static)`, which may be downcast.

Closes #370