### PR TITLE
Fix doc: codegen

### DIFF
--- a/src/guide/what_code_is_generated.md
+++ b/src/guide/what_code_is_generated.md
@@ -66,10 +66,9 @@ struct UserIdInvalidSnafu<I> {
     user_id: I,
 }
 
-struct ConfigValidationFailedSnafu {
-    checksum: u64,
-    key: String,
-    source: crypto::Error,
+struct ConfigValidationFailedSnafu<I, S> {
+    checksum: I,
+    key: S,
 }
 ```
 


### PR DESCRIPTION
Fields other than source should be given generic types.

I found this in reading the doc and felt very confusing because this is directly contradict to this description 

> Each remaining field’s type has been replaced with a generic type.