### PR TITLE
Add aliases for `[snafu(foo)]` to the `Snafu` macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,6 +274,19 @@ pub use report::CleanedErrorText;
 pub use report::{Report, __InternalExtractErrorType};
 
 #[doc = include_str!("Snafu.md")]
+#[doc(alias(
+    "backtrace",
+    "context",
+    "crate_root",
+    "display",
+    "implicit",
+    "module",
+    "provide",
+    "source",
+    "transparent",
+    "visibility",
+    "whatever",
+))]
 pub use snafu_derive::Snafu;
 
 #[doc = include_str!("report.md")]


### PR DESCRIPTION
This allows a search for `backtrace` to resolve to the macro, hinting where it is documented.