### PR TITLE
Mirror std Error's deprecated methods on our `Error` trait

### DIFF
--- a/src/no_std_error.rs
+++ b/src/no_std_error.rs
@@ -3,12 +3,19 @@
 use core::fmt::{Debug, Display};
 
 pub trait Error: Debug + Display {
+    #[deprecated(since = "1.42.0", note = "use the Display impl or to_string()")]
     fn description(&self) -> &str {
         "description() is deprecated; use Display"
     }
+
+    #[deprecated(
+        since = "1.33.0",
+        note = "replaced by Error::source, which can support downcasting"
+    )]
     fn cause(&self) -> Option<&dyn Error> {
         self.source()
     }
+
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         None
     }


### PR DESCRIPTION
Closes #425