### PR TITLE
Add missing generics and trait bounds to `FromString` impl

### DIFF
--- a/snafu-derive/src/shared.rs
+++ b/snafu-derive/src/shared.rs
@@ -358,8 +358,10 @@ pub mod context_selector {
             let parameterized_error_name = self.parameterized_error_name;
             let error_constructor_name = self.error_constructor_name;
             let construct_implicit_fields = self.construct_implicit_fields();
+            let original_generics_without_defaults = self.original_generics_without_defaults;
             let construct_implicit_fields_with_source =
                 self.construct_implicit_fields_with_source();
+            let extended_where_clauses = self.extended_where_clauses();
 
             // testme: transform
 
@@ -381,7 +383,10 @@ pub mod context_selector {
             let message_field_name = &message_field.name;
 
             quote! {
-                impl #crate_root::FromString for #parameterized_error_name {
+                impl<#(#original_generics_without_defaults,)*> #crate_root::FromString for #parameterized_error_name
+                where
+                    #(#extended_where_clauses),*
+                {
                     type Source = #source_ty;
 
                     #[track_caller]

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -62,6 +62,13 @@ mod bounds {
         enum Error<T: Display> {
             #[snafu(display("Boom: {value}"))]
             Boom { value: T },
+
+            #[snafu(whatever, display("{message}"))]
+            Whatever {
+                message: String,
+                #[snafu(source(from(Box<dyn std::error::Error>, Some)))]
+                source: Option<Box<dyn std::error::Error>>,
+            },
         }
 
         #[test]
@@ -88,6 +95,13 @@ mod bounds {
         {
             #[snafu(display("Boom: {value}"))]
             Boom { value: T },
+
+            #[snafu(whatever, display("{message}"))]
+            Whatever {
+                message: String,
+                #[snafu(source(from(Box<dyn std::error::Error>, Some)))]
+                source: Option<Box<dyn std::error::Error>>,
+            },
         }
 
         #[test]


### PR DESCRIPTION
Fixes #441

I'm still pretty ignorant when it comes to proc macros but I think this is correct. I need to write some tests tho.