### PR TITLE
Fixed Windows compile errors

### DIFF
--- a/tests/report.rs
+++ b/tests/report.rs
@@ -200,8 +200,13 @@ fn termination_returns_failure_code() {
 fn nasty_hack_exit_code_eq(left: ExitCode, right: ExitCode) -> bool {
     use std::mem;
 
-    let (left, right): (u8, u8) = unsafe {
-        assert_eq!(mem::size_of::<u8>(), mem::size_of::<ExitCode>());
+    #[cfg(target_os = "windows")]
+    type ExitCodeSize = u32;
+    #[cfg(not(target_os = "windows"))]
+    type ExitCodeSize = u8;
+
+    let (left, right): (ExitCodeSize, ExitCodeSize) = unsafe {
+        assert_eq!(mem::size_of::<ExitCodeSize>(), mem::size_of::<ExitCode>());
         (mem::transmute(left), mem::transmute(right))
     };
 


### PR DESCRIPTION
Currently when compiling on Windows (toolchain `stable-x86_64-pc-windows-msvc`), there is two compile errors.  Both compile errors are due to `men::transmute` calls in `nasty_hack_exit_code_eq`, which fail to compile due to transmuting a `ExitCode` of 32 bits into a 8 bit `u8`.  The error is:

```
error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
   --> tests\report.rs:210:10
    |
210 |         (mem::transmute(left), mem::transmute(right))
    |          ^^^^^^^^^^^^^^
    |
    = note: source type: `ExitCode` (32 bits)
    = note: target type: `u8` (8 bits)
```

This PR solves this problem by changing the transmute type to a u32 on Windows using conditional compilation.  The result is the project compiles and tests successfully on Windows.