### PR TITLE
Make Whatever thread-safe by default (add markers `Send + Sync`)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1561,9 +1561,9 @@ macro_rules! location {
 #[snafu(provide(opt, ref, chain, dyn std::error::Error => source.as_deref()))]
 #[cfg(any(feature = "std", test))]
 pub struct Whatever {
-    #[snafu(source(from(Box<dyn std::error::Error>, Some)))]
+    #[snafu(source(from(Box<dyn std::error::Error + Send + Sync>, Some)))]
     #[snafu(provide(false))]
-    source: Option<Box<dyn std::error::Error>>,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
     message: String,
     backtrace: Backtrace,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1558,7 +1558,7 @@ macro_rules! location {
 #[snafu(crate_root(crate))]
 #[snafu(whatever)]
 #[snafu(display("{message}"))]
-#[snafu(provide(opt, ref, chain, dyn std::error::Error => source.as_deref()))]
+#[snafu(provide(opt, ref, chain, dyn std::error::Error + Send + Sync => source.as_deref()))]
 #[cfg(any(feature = "std", test))]
 pub struct Whatever {
     #[snafu(source(from(Box<dyn std::error::Error + Send + Sync>, Some)))]

--- a/tests/backtrace.rs
+++ b/tests/backtrace.rs
@@ -130,7 +130,7 @@ mod whatever_nested {
         not_a_whatever().with_whatever_context(|_| format!("Outer failure"))
     }
 
-    fn not_a_whatever() -> Result<(), Box<dyn std::error::Error>> {
+    fn not_a_whatever() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         inner_whatever().map_err(Into::into)
     }
 


### PR DESCRIPTION
Allows Whatever's to be sent between threads by making them thread-safe by marking the source `std::error::Error` with `Send + Sync`.

For more discussion on why, see issue #446.

Resolves #446.