### PR TITLE
Mark more test types as deliberately unused

### DIFF
--- a/compatibility-tests/provider-api/src/lib.rs
+++ b/compatibility-tests/provider-api/src/lib.rs
@@ -563,12 +563,12 @@ mod doctests {
                 user_id: UserId,
             },
 
-            Logout {
+            _Logout {
                 #[snafu(provide)]
                 user_id: UserId,
             },
 
-            NetworkUnreachable {
+            _NetworkUnreachable {
                 source: std::io::Error,
             },
         }

--- a/tests/backtrace.rs
+++ b/tests/backtrace.rs
@@ -5,17 +5,17 @@ type AnotherError = Box<dyn std::error::Error>;
 #[derive(Debug, Snafu)]
 enum Error {
     #[snafu(display("Invalid user {user_id}:\n{backtrace}"))]
-    InvalidUser {
+    _InvalidUser {
         user_id: i32,
         backtrace: Backtrace,
     },
 
-    WithSource {
+    _WithSource {
         source: AnotherError,
         backtrace: Backtrace,
     },
 
-    WithSourceAndOtherInfo {
+    _WithSourceAndOtherInfo {
         user_id: i32,
         source: AnotherError,
         backtrace: Backtrace,

--- a/tests/display-shorthand.rs
+++ b/tests/display-shorthand.rs
@@ -45,7 +45,7 @@ fn supports_shorthand_formatting() {
 
 #[test]
 fn supports_positional_and_shorthand_formatting() {
-    let error = OnlyShorthandArgumentsSnafu {
+    let error = PositionalAndShorthandArgumentsSnafu {
         id: 42,
         name: "Anna",
     }

--- a/tests/doc_comment.rs
+++ b/tests/doc_comment.rs
@@ -13,7 +13,7 @@ enum Error {
     Stronger { stronger: &'static str },
 
     #[doc(hidden)]
-    Hidden,
+    _Hidden,
 }
 
 #[test]

--- a/tests/error_chain.rs
+++ b/tests/error_chain.rs
@@ -6,7 +6,7 @@ enum LeafError {
     #[snafu(display("User ID {user_id} is invalid"))]
     InvalidUser { user_id: i32 },
     #[snafu(display("no user available"))]
-    MissingUser,
+    _MissingUser,
 }
 
 #[derive(Debug, Clone, Snafu, PartialEq)]

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -61,7 +61,7 @@ mod bounds {
         #[derive(Debug, Snafu)]
         enum Error<T: Display> {
             #[snafu(display("Boom: {value}"))]
-            Boom { value: T },
+            _Boom { value: T },
 
             #[snafu(whatever, display("{message}"))]
             Whatever {
@@ -94,7 +94,7 @@ mod bounds {
             T: Display,
         {
             #[snafu(display("Boom: {value}"))]
-            Boom { value: T },
+            _Boom { value: T },
 
             #[snafu(whatever, display("{message}"))]
             Whatever {

--- a/tests/generics_with_default.rs
+++ b/tests/generics_with_default.rs
@@ -15,14 +15,16 @@ mod default_with_lifetime {
         S: std::error::Error + AsErrorSource,
     {
         #[snafu(display("Boom: {value}"))]
-        Boom {
+        _Boom {
             value: T,
             name: &'a str,
         },
-        WithSource {
+
+        _WithSource {
             source: S,
         },
-        Empty,
+
+        _Empty,
     }
 
     #[test]

--- a/tests/name-conflicts.rs
+++ b/tests/name-conflicts.rs
@@ -7,27 +7,27 @@ mod std {}
 mod snafu {}
 
 #[derive(Debug, Snafu)]
-enum VariantNamedNone {
+enum _VariantNamedNone {
     #[snafu(context(suffix(false)))]
     None,
 }
 
 #[derive(Debug, Snafu)]
-enum VariantNamedSome<T> {
+enum _VariantNamedSome<T> {
     Some { value: T },
 }
 
 #[derive(Debug, Snafu)]
-enum VariantNamedOk<T> {
+enum _VariantNamedOk<T> {
     Ok { value: T },
 }
 
 #[derive(Debug, Snafu)]
-enum VariantNamedErr<T> {
+enum _VariantNamedErr<T> {
     Err { value: T },
 }
 
-fn _using_ensure() -> Result<u8, VariantNamedNone> {
+fn _using_ensure() -> Result<u8, _VariantNamedNone> {
     ensure!(false, None);
     Ok(0)
 }

--- a/tests/no_context.rs
+++ b/tests/no_context.rs
@@ -2,12 +2,12 @@ use snafu::prelude::*;
 
 #[derive(Debug, Snafu)]
 enum AlphaError {
-    AlphaDummy,
+    _AlphaDummy,
 }
 
 #[derive(Debug, Snafu)]
 enum BetaError {
-    BetaDummy,
+    _BetaDummy,
 }
 
 #[derive(Debug, Snafu)]
@@ -67,7 +67,7 @@ mod with_bounds {
 
     #[derive(Debug, Snafu)]
     enum GenericError<T, U = i32> {
-        Something { things: T, other: U },
+        _Something { things: T, other: U },
     }
 
     #[derive(Debug, Snafu)]

--- a/tests/send_between_threads.rs
+++ b/tests/send_between_threads.rs
@@ -11,7 +11,7 @@ enum InnerError {
 
 #[derive(Debug, Snafu)]
 enum Error {
-    Leaf {
+    _Leaf {
         name: String,
     },
 
@@ -19,15 +19,15 @@ enum Error {
         source: InnerError,
     },
 
-    BoxedWrapper {
+    _BoxedWrapper {
         source: Box<InnerError>,
     },
 
-    BoxedTraitObjectSend {
+    _BoxedTraitObjectSend {
         source: Box<dyn std::error::Error + Send + 'static>,
     },
 
-    BoxedTraitObjectSendSync {
+    _BoxedTraitObjectSendSync {
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
 }

--- a/tests/source_attributes.rs
+++ b/tests/source_attributes.rs
@@ -2,7 +2,7 @@ use snafu::prelude::*;
 
 #[derive(Debug, Snafu)]
 enum InnerError {
-    Boom,
+    _Boom,
 }
 
 fn inner() -> Result<(), InnerError> {

--- a/tests/structs/single_use_lifetimes.rs
+++ b/tests/structs/single_use_lifetimes.rs
@@ -5,7 +5,7 @@ use snafu::prelude::*;
 #[test]
 fn an_error_with_generic_lifetimes_does_not_trigger_the_lint() {
     #[derive(Debug, Snafu)]
-    struct Error<'id> {
+    struct _Error<'id> {
         to: &'id u32,
     }
 }

--- a/tests/transparent.rs
+++ b/tests/transparent.rs
@@ -74,7 +74,7 @@ mod with_bounds {
 
     #[derive(Debug, Snafu)]
     enum GenericError<T, U = i32> {
-        Something { things: T, other: U },
+        _Something { things: T, other: U },
     }
 
     #[derive(Debug, Snafu)]

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -10,12 +10,14 @@ mod outer {
             PubCrate {
                 id: i32,
             },
+
             #[snafu(visibility(pub(in crate::outer)))]
             PubInPath {
                 id: i32,
             },
+
             #[snafu(visibility)]
-            Private {
+            _Private {
                 id: i32,
             },
         }


### PR DESCRIPTION
A chunk of our tests work by "does the procedural macro produce code that compiles?" which means we don't need to *use* the structs/enums/variants.

Did catch one bug though!