### PR TITLE
Make `Report::report` print the "Error: " prefix

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -188,7 +188,7 @@ where
         match self.0 {
             Ok(()) => ExitCode::SUCCESS,
             Err(e) => {
-                eprintln!("{}", ReportFormatter(&e));
+                eprintln!("Error: {}", ReportFormatter(&e));
 
                 #[cfg(feature = "unstable-provider-api")]
                 {

--- a/tests/report.rs
+++ b/tests/report.rs
@@ -142,6 +142,22 @@ fn debug_and_display_are_the_same() {
     assert_eq!(display, debug);
 }
 
+/// `Report as Termination` prints-out the "Error:" prefix.  Ensure that `Report as Display` does
+/// not also add such a prefix, to avoid printing-out "Error: Error: ...".
+#[test]
+fn display_not_prefixed() {
+    #[derive(Debug, Snafu)]
+    #[snafu(display("This is my Display text!"))]
+    struct Error;
+
+    let r = Report::from_error(Error);
+    let msg = r.to_string();
+    let msg = msg.trim_start();
+
+    assert!(!msg.starts_with("Err"));
+    assert!(!msg.starts_with("err"));
+}
+
 #[test]
 fn procedural_macro_works_with_result_return_type() {
     #[derive(Debug, Snafu)]


### PR DESCRIPTION
Fixes #452

---

#### My reasoning to address the concern mentioned in the issue:

> we just need to ensure that we don't end up printing `Error: Error: ...` when older versions of Rust are targeted.

It seems to me that is sufficiently ensured:

1. When `#[snafu::report]` transforms `main`, or a `#[test]` function, to return `-> Result<(), Report<E>>`, to support older versions of Rust (i.e. when the package feature `rust_1_61` is not enabled), or when that same return type was chosen explicitly (i.e. without using the attribute-macro), it is instead `Result as Termination` that is used.  That different implementation, with the `Error: ` prefix printed by it instead, uses the `Debug` formatting of `Report` (which is the same as its `Display` impl), for which SNAFU already does not add any prefix.  So, it's impossible for an extra prefix to be printed due to my change, for all preexisting and future uses of `<Result<T, Report<E>> as Termination>::report`.

2. Only `<Report as Termination>::report` is changed, and so the only way extra `Error:` (or the like) could be printed is if a user chooses to add their own such extra print before that function is called.

   1. Given [the narrow purpose](https://doc.rust-lang.org/std/process/trait.Termination.html#tymethod.report) of that function, it seems very unlikely that anyone is calling it other than implicitly after `main`, or a `#[test]` fn, returns.
      1. Even if some user has explicitly called `<T as Termination>::report` in a generic context anywhere (e.g. in the body of some test of that functionality), it seems likely they'd already be prepared for it to print the prefix, because the `std` library already does that for `Result`, and so they wouldn't have added their own printing of a prefix.
      2. It seems unlikely that anyone is explicitly calling only the specific concrete `<Report as Termination>::report`, but if they are then they shouldn't have relied on it to not print the prefix, because SNAFU's [documentation already implies](https://github.com/shepmaster/snafu/blob/117aeeea7699922d807ba0f897d494e13b84fb7a/src/report.md?plain=1#L64) that it will print the prefix.

   2. If any user has been printing their own prefix before `main`, or a `#[test]` fn, returns, then they should already be expecting an extra prefix, because without feature `rust_1_61` (e.g. for older versions of Rust) the `Error: ` prefix was already being printed by the `std` lib's `<Result<(), Report<E>> as Termination>::report`, and so such users should not have expected it to not continue doing that with newer Rust versions when `<Report as Termination>::report` is used in what was intended to be an equivalent internal-detail change.
   
3. SNAFU's documentation [says](https://docs.rs/snafu/0.8.2/snafu/struct.Report.html#stability-of-the-output):
      > The exact content and format of a displayed `Report` are not stable  

---

I added a test to ensure that `<Report as Display>::fmt` continues to not add an "error" prefix, to ensure that point 1 continues to be upheld.

I tried to think if any other tests should be added for any other aspects of this, but couldn't think of anything, because it's not possible to redirect the `stderr` output of a `#[test]` function to check it, nor did I notice any preexisting facility for checking the output of a test program (in contrast to the preexisting `compatibility-tests/compile-fail/`), as would be needed to test that the prefix is now being printed.