### PR TITLE
Add boxed_context and with_boxed_context

### DIFF
--- a/tests/location.rs
+++ b/tests/location.rs
@@ -135,11 +135,41 @@ mod track_caller {
     }
 
     #[test]
+    fn track_caller_is_applied_on_result_boxed_context() {
+        let base_line = line!();
+        let wrap_no_user_fields = InnerSnafu
+            .fail::<()>()
+            .boxed_context(WrapNoUserFieldsSnafu)
+            .unwrap_err();
+        assert_eq!(
+            wrap_no_user_fields.location.line,
+            base_line + 3,
+            "Actual location: {}",
+            wrap_no_user_fields.location,
+        );
+    }
+
+    #[test]
     fn track_caller_is_applied_on_result_with_context() {
         let base_line = line!();
         let wrap_no_user_fields = InnerSnafu
             .fail::<()>()
             .with_context(|_| WrapNoUserFieldsSnafu)
+            .unwrap_err();
+        assert_eq!(
+            wrap_no_user_fields.location.line,
+            base_line + 3,
+            "Actual location: {}",
+            wrap_no_user_fields.location,
+        );
+    }
+
+    #[test]
+    fn track_caller_is_applied_on_result_with_boxed_context() {
+        let base_line = line!();
+        let wrap_no_user_fields = InnerSnafu
+            .fail::<()>()
+            .with_boxed_context(|_| WrapNoUserFieldsSnafu)
             .unwrap_err();
         assert_eq!(
             wrap_no_user_fields.location.line,


### PR DESCRIPTION
Hi there,

First off, thanks for the work on snafu. I started using it a few months ago, and it's fantastic.

I've used it so thoroughly, that I'm now encountering warnings in a pretty large library I maintain where the error variant is getting quite large. As such, the compiler recommends that I return boxed errors, i.e. `Result<T, Box<E>>` instead of `Result<T, E>`.

`snafu` already provides a `Box<dyn Error>` return capability. Rightfully so, the documentation discourages its use. As such, I'm proposing the addition of `boxed_context` and `with_boxed_context`: they work as `context` and `with_context` respectively. 

Let me know if this is a fringe use case, and if so, what is the recommendation for returning a boxed error via `with_context`.

Thanks