### PR TITLE
Use full path for `location!()` macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1508,7 +1508,7 @@ impl fmt::Display for Location {
 #[macro_export]
 macro_rules! location {
     () => {
-        Location::new(file!(), line!(), column!())
+        $crate::Location::new(file!(), line!(), column!())
     };
 }
 


### PR DESCRIPTION
use full path of `snafu::Location` for `location!()` macro