### PR TITLE
Document cfg's on docs.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(missing_docs)]
 #![allow(stable_features)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![cfg_attr(feature = "unstable-core-error", feature(error_in_core))]
 #![cfg_attr(


### PR DESCRIPTION
Preview using `RUSTDOCFLAGS='--cfg=docsrs' cargo +nightly doc --features futures,guide --open`:

![Screenshot 2025-05-13 at 22-43-46 snafu - Rust](https://github.com/user-attachments/assets/9f93dde0-bc82-4c3f-8a58-3bc8d35f530b)
