### PR TITLE
Bring netlify preview closer to docs.rs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = """
 rustup install nightly --profile minimal && \
-RUSTDOCFLAGS='--cfg=docsrs' cargo +nightly doc --no-deps --features=futures,guide
+RUSTDOCFLAGS='--cfg=docsrs' cargo +nightly doc --no-deps --features=futures,guide -Zrustdoc-map
 """
 publish = "target/doc"
 


### PR DESCRIPTION
Doc references to non-sysroot crates are also going to work in the Netlify preview with this. For example: The `TryFuture` and `TryStream` links in the `futures` module.

This does not impact development with non-nightly toolchains, since they conveniently just ignore unstable settings in `.cargo/config.toml` (they do not ignore the same settings if passed via environment variable or CLI flag, IIRC).

Still, if you don't want to commit `.cargo/config.toml`, the same thing could probably be done via environment variables within `netlify.toml`.