### PR TITLE
Properly gate future/stream methods that require `alloc` behind the feature flag

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -105,7 +105,7 @@ stable_no_std_test_task:
 rust_1_81_no_std_test_task:
   name: "Rust 1.81 (no_std)"
   container:
-    image: rust:latest
+    image: rust:1.81
     cpu: 1
     memory: 2Gi
   cargo_cache:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -99,7 +99,8 @@ stable_no_std_test_task:
     - rustup target add thumbv6m-none-eabi
   our_error_test_script:
     - rustc --version
-    - cargo build --no-default-features --target thumbv6m-none-eabi
+    - cargo build --target thumbv6m-none-eabi --no-default-features
+    - cargo build --target thumbv6m-none-eabi --no-default-features --features=futures
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 rust_1_81_no_std_test_task:
@@ -115,7 +116,8 @@ rust_1_81_no_std_test_task:
     - rustup target add thumbv6m-none-eabi
   core_error_test_script:
     - rustc --version
-    - cargo build --no-default-features --features=rust_1_81 --target thumbv6m-none-eabi
+    - cargo build --target thumbv6m-none-eabi --no-default-features --features=rust_1_81
+    - cargo build --target thumbv6m-none-eabi --no-default-features --features=rust_1_81,futures
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 nightly_test_task:

--- a/src/futures/try_future.rs
+++ b/src/futures/try_future.rs
@@ -2,8 +2,7 @@
 //!
 //! [`TryFuture`]: futures_core_crate::future::TryFuture
 
-use crate::{Error, ErrorCompat, FromString, IntoError};
-use alloc::string::String;
+use crate::{Error, ErrorCompat, IntoError};
 use core::{
     future::Future,
     marker::PhantomData,
@@ -12,6 +11,12 @@ use core::{
 };
 use futures_core_crate::future::TryFuture;
 use pin_project::pin_project;
+
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+
+#[cfg(feature = "alloc")]
+use crate::FromString;
 
 /// Additions to [`TryFuture`].
 pub trait TryFutureExt: TryFuture + Sized {
@@ -119,6 +124,7 @@ pub trait TryFutureExt: TryFuture + Sized {
     /// # futures::future::ok(42)
     /// }
     /// ```
+    #[cfg(any(feature = "alloc", test))]
     fn whatever_context<S, E>(self, context: S) -> WhateverContext<Self, S, E>
     where
         S: Into<String>,
@@ -148,6 +154,7 @@ pub trait TryFutureExt: TryFuture + Sized {
     /// # futures::future::ok(42)
     /// }
     /// ```
+    #[cfg(any(feature = "alloc", test))]
     fn with_whatever_context<F, S, E>(self, context: F) -> WithWhateverContext<Self, F, E>
     where
         F: FnOnce(&mut Self::Error) -> S,
@@ -184,6 +191,7 @@ where
         }
     }
 
+    #[cfg(any(feature = "alloc", test))]
     fn whatever_context<S, E>(self, context: S) -> WhateverContext<Self, S, E>
     where
         S: Into<String>,
@@ -196,6 +204,7 @@ where
         }
     }
 
+    #[cfg(any(feature = "alloc", test))]
     fn with_whatever_context<F, S, E>(self, context: F) -> WithWhateverContext<Self, F, E>
     where
         F: FnOnce(&mut Self::Error) -> S,
@@ -305,6 +314,7 @@ where
 #[pin_project]
 #[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
+#[cfg(any(feature = "alloc", test))]
 pub struct WhateverContext<Fut, S, E> {
     #[pin]
     inner: Fut,
@@ -312,6 +322,7 @@ pub struct WhateverContext<Fut, S, E> {
     _e: PhantomData<E>,
 }
 
+#[cfg(any(feature = "alloc", test))]
 impl<Fut, S, E> Future for WhateverContext<Fut, S, E>
 where
     Fut: TryFuture,
@@ -352,6 +363,7 @@ where
 #[pin_project]
 #[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
+#[cfg(any(feature = "alloc", test))]
 pub struct WithWhateverContext<Fut, F, E> {
     #[pin]
     inner: Fut,
@@ -359,6 +371,7 @@ pub struct WithWhateverContext<Fut, F, E> {
     _e: PhantomData<E>,
 }
 
+#[cfg(any(feature = "alloc", test))]
 impl<Fut, F, S, E> Future for WithWhateverContext<Fut, F, E>
 where
     Fut: TryFuture,

--- a/src/futures/try_stream.rs
+++ b/src/futures/try_stream.rs
@@ -2,8 +2,7 @@
 //!
 //! [`TryStream`]: futures_core_crate::TryStream
 
-use crate::{Error, ErrorCompat, FromString, IntoError};
-use alloc::string::String;
+use crate::{Error, ErrorCompat, IntoError};
 use core::{
     marker::PhantomData,
     pin::Pin,
@@ -11,6 +10,12 @@ use core::{
 };
 use futures_core_crate::stream::{Stream, TryStream};
 use pin_project::pin_project;
+
+#[cfg(any(feature = "alloc", test))]
+use alloc::string::String;
+
+#[cfg(any(feature = "alloc", test))]
+use crate::FromString;
 
 /// Additions to [`TryStream`].
 pub trait TryStreamExt: TryStream + Sized {
@@ -121,6 +126,7 @@ pub trait TryStreamExt: TryStream + Sized {
     /// # stream::empty()
     /// }
     /// ```
+    #[cfg(any(feature = "alloc", test))]
     fn whatever_context<S, E>(self, context: S) -> WhateverContext<Self, S, E>
     where
         S: Into<String>,
@@ -151,6 +157,7 @@ pub trait TryStreamExt: TryStream + Sized {
     /// # stream::empty()
     /// }
     /// ```
+    #[cfg(any(feature = "alloc", test))]
     fn with_whatever_context<F, S, E>(self, context: F) -> WithWhateverContext<Self, F, E>
     where
         F: FnMut(&mut Self::Error) -> S,
@@ -187,6 +194,7 @@ where
         }
     }
 
+    #[cfg(any(feature = "alloc", test))]
     fn whatever_context<S, E>(self, context: S) -> WhateverContext<Self, S, E>
     where
         S: Into<String>,
@@ -199,6 +207,7 @@ where
         }
     }
 
+    #[cfg(any(feature = "alloc", test))]
     fn with_whatever_context<F, S, E>(self, context: F) -> WithWhateverContext<Self, F, E>
     where
         F: FnMut(&mut Self::Error) -> S,
@@ -300,6 +309,7 @@ where
 #[pin_project]
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
+#[cfg(any(feature = "alloc", test))]
 pub struct WhateverContext<St, S, E> {
     #[pin]
     inner: St,
@@ -307,6 +317,7 @@ pub struct WhateverContext<St, S, E> {
     _e: PhantomData<E>,
 }
 
+#[cfg(any(feature = "alloc", test))]
 impl<St, S, E> Stream for WhateverContext<St, S, E>
 where
     St: TryStream,
@@ -343,6 +354,7 @@ where
 #[pin_project]
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
+#[cfg(any(feature = "alloc", test))]
 pub struct WithWhateverContext<St, F, E> {
     #[pin]
     inner: St,
@@ -350,6 +362,7 @@ pub struct WithWhateverContext<St, F, E> {
     _e: PhantomData<E>,
 }
 
+#[cfg(any(feature = "alloc", test))]
 impl<St, F, S, E> Stream for WithWhateverContext<St, F, E>
 where
     St: TryStream,


### PR DESCRIPTION
Closes #510 