### PR TITLE
Only implement for `Arc` when the target platform has atomics

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -118,6 +118,8 @@ rust_1_81_no_std_test_task:
     - rustc --version
     - cargo build --target thumbv6m-none-eabi --no-default-features --features=rust_1_81
     - cargo build --target thumbv6m-none-eabi --no-default-features --features=rust_1_81,futures
+    - cargo build --target thumbv6m-none-eabi --no-default-features --features=rust_1_81,alloc
+    - cargo build --target thumbv6m-none-eabi --no-default-features --features=rust_1_81,alloc,futures
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 nightly_test_task:

--- a/src/boxed_impls.rs
+++ b/src/boxed_impls.rs
@@ -1,4 +1,10 @@
-use alloc::{boxed::Box, rc::Rc, sync::Arc};
+use alloc::{boxed::Box, rc::Rc};
+
+// `target_has_atomic` wasn't stabilized until 1.60. Thankfully, we
+// don't support no_std + alloc without Rust 1.81. After the MSRV is
+// bumped to >= 1.60, this can be simplified to `target_has_atomic`.
+#[cfg(any(feature = "std", all(feature = "rust_1_61", target_has_atomic = "ptr")))]
+use alloc::sync::Arc;
 
 use super::{AsBacktrace, Backtrace, ErrorCompat, GenerateImplicitData};
 
@@ -47,6 +53,7 @@ where
     }
 }
 
+#[cfg(any(feature = "std", all(feature = "rust_1_61", target_has_atomic = "ptr")))]
 impl<T> GenerateImplicitData for Arc<T>
 where
     T: GenerateImplicitData,
@@ -83,6 +90,7 @@ where
     }
 }
 
+#[cfg(any(feature = "std", all(feature = "rust_1_61", target_has_atomic = "ptr")))]
 impl<T> AsBacktrace for Arc<T>
 where
     T: AsBacktrace,


### PR DESCRIPTION
Add a CI check as well.