### PR TITLE
Allow using a generic for construction via From

### DIFF
--- a/compatibility-tests/compile-fail/tests/ui/attribute-unparseable.rs
+++ b/compatibility-tests/compile-fail/tests/ui/attribute-unparseable.rs
@@ -1,9 +1,7 @@
 use snafu::prelude::*;
 
 #[derive(Debug, Snafu)]
-enum InnerError {
-    InnerVariant,
-}
+struct InnerError;
 
 #[derive(Debug, Snafu)]
 enum Error {
@@ -12,6 +10,12 @@ enum Error {
         #[snafu(source(5))]
         a: InnerError,
     },
+}
+
+#[derive(Debug, Snafu)]
+struct SourceFromTransformInvalidType {
+    #[snafu(source(from(Cow*, ?)))]
+    source: InnerError,
 }
 
 fn main() {}

--- a/compatibility-tests/compile-fail/tests/ui/attribute-unparseable.stderr
+++ b/compatibility-tests/compile-fail/tests/ui/attribute-unparseable.stderr
@@ -1,5 +1,17 @@
 error: expected boolean literal or `from`
-  --> tests/ui/attribute-unparseable.rs:12:24
+  --> tests/ui/attribute-unparseable.rs:10:24
    |
-12 |         #[snafu(source(5))]
+10 |         #[snafu(source(5))]
    |                        ^
+
+error: expected one of: `exact`, `generic` or a type followed by a comma and an expression
+  --> tests/ui/attribute-unparseable.rs:17:25
+   |
+17 |     #[snafu(source(from(Cow*, ?)))]
+   |                         ^^^
+
+error: expected `,`
+  --> tests/ui/attribute-unparseable.rs:17:28
+   |
+17 |     #[snafu(source(from(Cow*, ?)))]
+   |                            ^

--- a/compatibility-tests/compile-fail/tests/ui/from-generic.rs
+++ b/compatibility-tests/compile-fail/tests/ui/from-generic.rs
@@ -1,0 +1,20 @@
+use snafu::prelude::*;
+
+#[derive(Debug, Snafu)]
+struct DummyError;
+
+#[derive(Debug, Snafu)]
+enum EnumErrorWithGenericSourceAndContextSelector {
+    TheVariant {
+        #[snafu(source(from(generic)))]
+        source: DummyError,
+    },
+}
+
+#[derive(Debug, Snafu)]
+struct StructErrorWithGenericSourceAndContextSelector {
+    #[snafu(source(from(generic)))]
+    source: DummyError,
+}
+
+fn main() {}

--- a/compatibility-tests/compile-fail/tests/ui/from-generic.stderr
+++ b/compatibility-tests/compile-fail/tests/ui/from-generic.stderr
@@ -1,0 +1,11 @@
+error: Cannot use `source(from(generic))` without disabling the context selector with `context(false)` or `transparent`
+ --> tests/ui/from-generic.rs:9:17
+  |
+9 |         #[snafu(source(from(generic)))]
+  |                 ^^^^^^^^^^^^^^^^^^^^^
+
+error: Cannot use `source(from(generic))` without disabling the context selector with `context(false)` or `transparent`
+  --> tests/ui/from-generic.rs:16:13
+   |
+16 |     #[snafu(source(from(generic)))]
+   |             ^^^^^^^^^^^^^^^^^^^^^

--- a/snafu-derive/src/parse/field_container_impl.rs
+++ b/snafu-derive/src/parse/field_container_impl.rs
@@ -221,6 +221,13 @@ pub(super) fn parse_field_container(
         _ => {} // no conflict
     }
 
+    if let Some(Sidecar(span, source_field)) = &source {
+        if source_field.transformation.is_generic() && !selector_kind.is_without_context() {
+            let txt = "Cannot use `source(from(generic))` without disabling the context selector with `context(false)` or `transparent`";
+            errors.push_new(span, txt);
+        }
+    }
+
     let source_field = source.map(|Sidecar(_, val)| val);
     let backtrace_field = backtrace.map(|Sidecar(_, val)| val);
     let is_transparent = selector_kind.is_transparent();
@@ -324,6 +331,10 @@ impl IntermediateSelectorKind {
                 source: WithoutContextSource::Transparent
             }
         )
+    }
+
+    fn is_without_context(&self) -> bool {
+        matches!(self, IntermediateSelectorKind::WithoutContext { .. })
     }
 }
 


### PR DESCRIPTION
TL;DR, SNAFU learns this:

```rust
#[derive(Debug, Snafu)]
#[snafu(source(from(generic)))]
struct OuterError(MiddleError);
```

which effectively generates this implementation:

```rust
impl<Source> From<Source> for OuterError
where
    Source: Into<MiddleError>,
{
    fn from(error: Source) -> Self {
        OuterError(error.into())
    }
}
```

This applies to
- opaque errors
- `context(false)`
- `transparent`

Resolves #481, resolves #518