### PR TITLE
Use namespaced dependency activation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ alloc = []
 rust_1_81 = []
 
 # The backtrace type becomes `backtrace::Backtrace`
-backtraces-impl-backtrace-crate = ["backtrace"]
+backtraces-impl-backtrace-crate = ["dep:backtrace"]
 
 # The std::error::Error provider API will be implemented.
 unstable-provider-api = ["snafu-derive/unstable-provider-api"]
@@ -50,14 +50,21 @@ unstable-provider-api = ["snafu-derive/unstable-provider-api"]
 unstable-try-trait = []
 
 # The standard library's implementation of futures
-futures = ["futures-core-crate", "pin-project"]
+futures = ["dep:futures-core", "dep:pin-project"]
 
 # Include the built-in user guide documentation
 guide = []
 
 # No public user should make use of this feature
 # https://github.com/rust-lang/cargo/issues/1596
-"internal-dev-dependencies" = ["futures-crate"]
+"internal-dev-dependencies" = ["dep:futures"]
+
+# these do nothing and should be removed with the next breaking release
+# they only exist for backwards compatibility with prior implicit features
+backtrace = []
+futures-crate = []
+futures-core-crate = []
+pin-project = []
 
 [workspace]
 # The compatibility tests each set feature flags for the library and
@@ -67,6 +74,6 @@ exclude = ["compatibility-tests"]
 [dependencies]
 snafu-derive = { path = "snafu-derive", version = "0.9.0" }
 backtrace = { version = "0.3.0", optional = true, default-features = false, features = ["std"] }
-futures-crate = { package = "futures", version = "0.3.11", optional = true, default-features = false, features = ["executor"] }
-futures-core-crate = { package = "futures-core", version = "0.3.0", optional = true, default-features = false }
+futures = { version = "0.3.11", optional = true, default-features = false, features = ["executor"] }
+futures-core = { version = "0.3.0", optional = true, default-features = false }
 pin-project = { version = "1.0.2", optional = true, default-features = false }

--- a/src/futures/mod.rs
+++ b/src/futures/mod.rs
@@ -3,8 +3,8 @@
 //! This module is only available when the `futures` [feature flag] is
 //! enabled.
 //!
-//! [`TryFuture`]: futures_core_crate::TryFuture
-//! [`TryStream`]: futures_core_crate::TryStream
+//! [`TryFuture`]: futures_core::TryFuture
+//! [`TryStream`]: futures_core::TryStream
 //! [feature flag]: crate::guide::feature_flags
 
 pub mod try_future;

--- a/src/futures/try_future.rs
+++ b/src/futures/try_future.rs
@@ -1,6 +1,6 @@
 //! Additions to the [`TryFuture`] trait.
 //!
-//! [`TryFuture`]: futures_core_crate::future::TryFuture
+//! [`TryFuture`]: futures_core::future::TryFuture
 
 use crate::{Error, ErrorCompat, IntoError};
 use core::{
@@ -9,7 +9,7 @@ use core::{
     pin::Pin,
     task::{Context as TaskContext, Poll},
 };
-use futures_core_crate::future::TryFuture;
+use futures_core::future::TryFuture;
 use pin_project::pin_project;
 
 #[cfg(feature = "alloc")]
@@ -25,7 +25,6 @@ pub trait TryFutureExt: TryFuture + Sized {
     ///
     /// ```rust
     /// # #[cfg(feature = "internal-dev-dependencies")] {
-    /// # use futures_crate as futures;
     /// use futures::future::TryFuture;
     /// use snafu::prelude::*;
     ///
@@ -65,7 +64,6 @@ pub trait TryFutureExt: TryFuture + Sized {
     ///
     /// ```rust
     /// # #[cfg(feature = "internal-dev-dependencies")] {
-    /// # use futures_crate as futures;
     /// use futures::future::TryFuture;
     /// use snafu::prelude::*;
     ///
@@ -115,7 +113,6 @@ pub trait TryFutureExt: TryFuture + Sized {
     ///
     /// ```rust
     /// # #[cfg(feature = "internal-dev-dependencies")] {
-    /// # use futures_crate as futures;
     /// use futures::future::TryFuture;
     /// use snafu::{prelude::*, Whatever};
     ///
@@ -146,7 +143,6 @@ pub trait TryFutureExt: TryFuture + Sized {
     ///
     /// ```rust
     /// # #[cfg(feature = "internal-dev-dependencies")] {
-    /// # use futures_crate as futures;
     /// use futures::future::TryFuture;
     /// use snafu::{prelude::*, Whatever};
     ///

--- a/src/futures/try_stream.rs
+++ b/src/futures/try_stream.rs
@@ -1,6 +1,6 @@
 //! Additions to the [`TryStream`] trait.
 //!
-//! [`TryStream`]: futures_core_crate::TryStream
+//! [`TryStream`]: futures_core::TryStream
 
 use crate::{Error, ErrorCompat, IntoError};
 use core::{
@@ -8,7 +8,7 @@ use core::{
     pin::Pin,
     task::{Context as TaskContext, Poll},
 };
-use futures_core_crate::stream::{Stream, TryStream};
+use futures_core::stream::{Stream, TryStream};
 use pin_project::pin_project;
 
 #[cfg(any(feature = "alloc", test))]
@@ -24,7 +24,6 @@ pub trait TryStreamExt: TryStream + Sized {
     ///
     /// ```rust
     /// # #[cfg(feature = "internal-dev-dependencies")] {
-    /// # use futures_crate as futures;
     /// use futures::TryStream;
     /// # use futures::stream;
     /// use snafu::prelude::*;
@@ -65,7 +64,6 @@ pub trait TryStreamExt: TryStream + Sized {
     ///
     /// ```rust
     /// # #[cfg(feature = "internal-dev-dependencies")] {
-    /// # use futures_crate as futures;
     /// use futures::TryStream;
     /// # use futures::stream;
     /// use snafu::prelude::*;
@@ -116,7 +114,6 @@ pub trait TryStreamExt: TryStream + Sized {
     ///
     /// ```rust
     /// # #[cfg(feature = "internal-dev-dependencies")] {
-    /// # use futures_crate as futures;
     /// use futures::TryStream;
     /// # use futures::stream;
     /// use snafu::{prelude::*, Whatever};
@@ -148,7 +145,6 @@ pub trait TryStreamExt: TryStream + Sized {
     ///
     /// ```rust
     /// # #[cfg(feature = "internal-dev-dependencies")] {
-    /// # use futures_crate as futures;
     /// use futures::TryStream;
     /// # use futures::stream;
     /// use snafu::{prelude::*, Whatever};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1521,7 +1521,6 @@ fn backtrace_collection_enabled() -> bool {
 ///
 /// ```rust
 /// # #[cfg(all(feature = "futures", feature = "internal-dev-dependencies"))] {
-/// # use futures_crate as futures;
 /// # use snafu::{prelude::*, Location, location};
 /// # let body = async {
 /// // Non-ideal: will report where `wrapped_error_future` is `.await`ed.


### PR DESCRIPTION
Stabilized in 1.60, which is lower than the current MSRV: https://blog.rust-lang.org/2022/04/07/Rust-1.60.0/#new-syntax-for-cargo-features