### PR TITLE
Expand Self to the name of the error type when generating selectors

### DIFF
--- a/snafu-derive/Cargo.toml
+++ b/snafu-derive/Cargo.toml
@@ -32,4 +32,5 @@ features = [
     "parsing",
     "printing",
     "proc-macro",
+    "visit-mut",
 ]

--- a/snafu-derive/src/lib.rs
+++ b/snafu-derive/src/lib.rs
@@ -290,8 +290,50 @@ fn impl_snafu_macro(ty: syn::DeriveInput) -> TokenStream {
     }
 }
 
+const SELF_TYPE: &str = "Self";
+
+struct ExpandSelfVisitor {
+    self_ty: syn::TypePath,
+}
+
+impl syn::visit_mut::VisitMut for ExpandSelfVisitor {
+    fn visit_type_path_mut(&mut self, node: &mut syn::TypePath) {
+        // Terminate on `Self` nodes.
+        if node.qself.is_none() && node.path.is_ident(SELF_TYPE) {
+            *node = self.self_ty.clone();
+            return;
+        }
+        // Continue recursive visiting.
+        syn::visit_mut::visit_type_path_mut(self, node);
+    }
+}
+
+/// Returns a `DeriveInput` with all occurrences of `Self` replaced
+/// with its name.
+///
+/// We use pieces of the original code to create context selector
+/// types and implementations. If `Self` is copied verbatim, it will
+/// change its meaning from the error type the user provided to the
+/// context selector. Instead, we eagerly resolve `Self` to the name
+/// of the original type.
+fn expand_self(mut input: syn::DeriveInput) -> syn::DeriveInput {
+    let mut v = ExpandSelfVisitor {
+        self_ty: syn::TypePath {
+            qself: None,
+            // We don't need to worry about fully qualifying the original type
+            // name because we either refer to it from the same module, or from
+            // a child module that imports everything from the parent module.
+            path: input.ident.clone().into(),
+        },
+    };
+    syn::visit_mut::visit_derive_input_mut(&mut v, &mut input);
+    input
+}
+
 fn parse_snafu_information(ty: syn::DeriveInput) -> syn::Result<SnafuInfo> {
     use syn::Data;
+
+    let ty = expand_self(ty);
 
     let syn::DeriveInput {
         ident,

--- a/tests/nested_self.rs
+++ b/tests/nested_self.rs
@@ -1,0 +1,82 @@
+use snafu::prelude::*;
+
+#[test]
+fn self_in_source_field() {
+    #[derive(Debug, PartialEq, Snafu)]
+    enum Error {
+        NonRecursive,
+        Recursive {
+            #[snafu(source(from(Error, Box::new)))]
+            source: Box<Self>,
+        },
+    }
+
+    let e = NonRecursiveSnafu
+        .fail::<i32>()
+        .context(RecursiveSnafu)
+        .unwrap_err();
+
+    assert_eq!(
+        e,
+        Error::Recursive {
+            source: Box::new(Error::NonRecursive)
+        },
+    );
+}
+
+#[test]
+fn self_in_implicit_field() {
+    #[derive(Debug, PartialEq)]
+    struct ImplicitType<T>(T);
+    impl snafu::GenerateImplicitData for ImplicitType<Box<Error>> {
+        fn generate() -> Self {
+            Self(Box::new(Error::NonRecursive { value: 123 }))
+        }
+    }
+    #[derive(Debug, PartialEq, Snafu)]
+    enum Error {
+        NonRecursive {
+            value: i32,
+        },
+        Recursive {
+            #[snafu(implicit)]
+            a_field: ImplicitType<Box<Self>>,
+        },
+    }
+
+    let e = RecursiveSnafu.build();
+
+    assert_eq!(
+        e,
+        Error::Recursive {
+            a_field: ImplicitType(Box::new(Error::NonRecursive { value: 123 })),
+        },
+    );
+}
+
+#[test]
+fn self_in_user_field() {
+    #[derive(Debug, PartialEq, Snafu)]
+    enum Error {
+        NonRecursive { value: i32 },
+        Recursive { other: Vec<Self> },
+    }
+
+    let e = RecursiveSnafu {
+        other: vec![
+            NonRecursiveSnafu { value: 1 }.build(),
+            NonRecursiveSnafu { value: 2 }.build(),
+        ],
+    }
+    .build();
+
+    assert_eq!(
+        e,
+        Error::Recursive {
+            other: vec![
+                Error::NonRecursive { value: 1 },
+                Error::NonRecursive { value: 2 },
+            ],
+        },
+    );
+}

--- a/tests/self_in_trait_bounds.rs
+++ b/tests/self_in_trait_bounds.rs
@@ -1,0 +1,42 @@
+#[test]
+fn self_in_enum_bounds() {
+    #[derive(Debug, PartialEq, snafu::Snafu)]
+    enum Error
+    where
+        i32: From<Self>,
+    {
+        Variant { value: i32 },
+    }
+    impl From<Error> for i32 {
+        fn from(value: Error) -> Self {
+            let Error::Variant { value } = value;
+            value
+        }
+    }
+
+    let e = VariantSnafu { value: 1 }.build();
+
+    assert_eq!(e, Error::Variant { value: 1 });
+    assert_eq!(Into::<i32>::into(e), 1);
+}
+
+#[test]
+fn self_in_struct_bounds() {
+    #[derive(Debug, PartialEq, snafu::Snafu)]
+    struct Error
+    where
+        i32: From<Self>,
+    {
+        value: i32,
+    }
+    impl From<Error> for i32 {
+        fn from(value: Error) -> Self {
+            value.value
+        }
+    }
+
+    let e = Snafu { value: 1 }.build();
+
+    assert_eq!(e, Error { value: 1 });
+    assert_eq!(Into::<i32>::into(e), 1);
+}

--- a/tests/structs/main.rs
+++ b/tests/structs/main.rs
@@ -8,6 +8,7 @@ mod display;
 mod from_option;
 mod generics;
 mod module;
+mod nested_self;
 mod no_context;
 mod single_use_lifetimes;
 mod source_attributes;

--- a/tests/structs/nested_self.rs
+++ b/tests/structs/nested_self.rs
@@ -1,0 +1,79 @@
+use std::marker::PhantomData;
+
+use snafu::prelude::*;
+
+#[test]
+fn self_in_source_field() {
+    #[derive(Debug, PartialEq, Snafu)]
+    struct TerminatingError<T> {
+        marker: PhantomData<T>,
+    }
+    #[derive(Debug, PartialEq, Snafu)]
+    struct Error {
+        source: TerminatingError<Self>,
+    }
+    let source: Result<(), _> = TerminatingSnafu {
+        marker: PhantomData::default(),
+    }
+    .fail();
+
+    let e = source.context(Snafu).unwrap_err();
+
+    assert_eq!(
+        e,
+        Error {
+            source: TerminatingError {
+                marker: PhantomData::default(),
+            }
+        },
+    );
+}
+
+#[test]
+fn self_in_implicit_field() {
+    #[derive(Debug, PartialEq)]
+    struct ImplicitType<T>(T);
+    impl snafu::GenerateImplicitData for ImplicitType<Option<Box<Error>>> {
+        fn generate() -> Self {
+            Self(Some(Box::new(Error { value: Self(None) })))
+        }
+    }
+    #[derive(Debug, PartialEq, Snafu)]
+    struct Error {
+        // Option is necessary to make this terminate.
+        // Box is necessary to make the size finite.
+        #[snafu(implicit)]
+        value: ImplicitType<Option<Box<Self>>>,
+    }
+
+    let e = Snafu.build();
+
+    assert_eq!(
+        e,
+        Error {
+            value: ImplicitType(Some(Box::new(Error {
+                value: ImplicitType(None),
+            }))),
+        },
+    );
+}
+
+#[test]
+fn self_in_user_field() {
+    #[derive(Debug, PartialEq, Snafu)]
+    struct Error {
+        other: Option<Box<Self>>,
+    }
+
+    let e = Snafu {
+        other: Some(Box::new(Snafu { other: None }.build())),
+    }
+    .build();
+
+    assert_eq!(
+        e,
+        Error {
+            other: Some(Box::new(Error { other: None })),
+        },
+    );
+}


### PR DESCRIPTION
Self used inside a field type always refers to the error type itself. Previously such a type was copied verbatim to the *Snafu selector type, which changes the meaning of Self from the error type to the selector type. This change expands Self when capturing the field type.

The type expansion is implemented using a visit_type_path_mut provided by the syn crate.

Closes #218.