### PR TITLE
Do not trigger the `semicolon_in_expressions_from_macros` lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,7 +541,7 @@ macro_rules! whatever {
             $crate::FromString::without_source(
                 $crate::__format!($fmt$(, $($arg),*)*),
             )
-        });
+        })
     };
     ($source:expr, $fmt:literal$(, $($arg:expr),* $(,)?)*) => {
         match $source {


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/79813

We cannot usefully write a test for this as the lint has historically not been applied to macros from other crates. We only test the `whatever` macro through doctests and integration tests, which count as "other crates" for our purposes. It appears that only recently has the lint been expanded to go across crates, but it's already deny-by-default.

In lieu of a test, we can reproduce the error by running `cargo test` with a specific nightly. I used `cargo 1.99.0-nightly (3efb1f477 2026-07-17)`.