### PR TITLE
Add ResultExt::unwrap_report

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -866,6 +866,39 @@ pub trait ResultExt<T, E>: Sized {
     fn boxed_local<'a>(self) -> Result<T, Box<dyn Error + 'a>>
     where
         E: Error + 'a;
+
+    /// Unwrap this result, returning the contained [`Ok`] value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is an [`Err`], after printing the error as a
+    /// [`Report`]. Unlike [`Result::unwrap`], which formats the error with
+    /// its `Debug` implementation, this formats the error and its source
+    /// chain with their `Display` implementation, which is usually the more
+    /// readable choice when reporting an error to a person.
+    ///
+    /// ```rust
+    /// use snafu::prelude::*;
+    ///
+    /// #[derive(Debug, Snafu)]
+    /// struct PlaceholderError;
+    ///
+    /// fn may_succeed() -> Result<u8, PlaceholderError> {
+    ///     Ok(42)
+    /// }
+    ///
+    /// let value = may_succeed().unwrap_report();
+    /// assert_eq!(value, 42);
+    /// ```
+    ///
+    /// [`Ok`]: std::result::Result::Ok
+    /// [`Err`]: std::result::Result::Err
+    /// [`Result::unwrap`]: std::result::Result::unwrap
+    /// [`Report`]: crate::Report
+    #[track_caller]
+    fn unwrap_report(self) -> T
+    where
+        E: Error;
 }
 
 impl<T, E> ResultExt<T, E> for Result<T, E> {
@@ -947,6 +980,17 @@ impl<T, E> ResultExt<T, E> for Result<T, E> {
         E: Error + 'a,
     {
         self.map_err(|e| Box::new(e) as _)
+    }
+
+    #[track_caller]
+    fn unwrap_report(self) -> T
+    where
+        E: Error,
+    {
+        match self {
+            Ok(v) => v,
+            Err(e) => panic!("{}", Report::from_error(e)),
+        }
     }
 }
 

--- a/tests/report.rs
+++ b/tests/report.rs
@@ -293,3 +293,31 @@ fn cleaning_nested_errors_removes_duplication() {
     assert_cleaning_step(&mut iter, "But I am only C", "");
     assert!(iter.next().is_none());
 }
+
+#[test]
+fn unwrap_report_returns_the_ok_value() {
+    #[derive(Debug, Snafu)]
+    #[snafu(display("This is my Display text!"))]
+    struct Error;
+
+    let r: Result<u8, Error> = Ok(42);
+    assert_eq!(r.unwrap_report(), 42);
+}
+
+#[test]
+#[should_panic(expected = "This is my inner Display")]
+fn unwrap_report_panics_with_the_report_display() {
+    #[derive(Debug, Snafu)]
+    #[snafu(display("This is my inner Display"))]
+    struct InnerError;
+
+    #[derive(Debug, Snafu)]
+    #[snafu(display("This is my outer Display"))]
+    struct OuterError {
+        source: InnerError,
+    }
+
+    let e = OuterSnafu.into_error(InnerError);
+    let r: Result<(), OuterError> = Err(e);
+    r.unwrap_report();
+}


### PR DESCRIPTION
Closes #375. Adds `unwrap_report` to `ResultExt`, following the sketch in the issue: on `Err` it panics with a `Report` of the error, so you get the `Display` output and the source chain instead of the `Debug` dump that `Result::unwrap` gives you.

I went with the name from the issue title. It's `#[track_caller]` like the other methods, and there are two integration tests in tests/report.rs covering the Ok path and the panic message.